### PR TITLE
Add classes to druid-api to facilitate the creation of storage and firehose implementations purely from the druid-api jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <name>druid-api</name>
     <description>druid-api</description>
     <scm>
@@ -60,6 +60,20 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/druid/data/input/ByteBufferInputRowParser.java
+++ b/src/main/java/io/druid/data/input/ByteBufferInputRowParser.java
@@ -1,0 +1,16 @@
+package io.druid.data.input;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.druid.data.input.impl.InputRowParser;
+import io.druid.data.input.impl.StringInputRowParser;
+
+import java.nio.ByteBuffer;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = StringInputRowParser.class)
+@JsonSubTypes(value = {
+        @JsonSubTypes.Type(name = "string", value = StringInputRowParser.class)
+})
+public interface ByteBufferInputRowParser extends InputRowParser<ByteBuffer>
+{
+}

--- a/src/main/java/io/druid/data/input/Firehose.java
+++ b/src/main/java/io/druid/data/input/Firehose.java
@@ -1,25 +1,4 @@
-/*
- * Druid - a distributed column store.
- * Copyright (C) 2012, 2013  Metamarkets Group Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 package io.druid.data.input;
-
-import io.druid.data.input.InputRow;
 
 import java.io.Closeable;
 

--- a/src/main/java/io/druid/data/input/impl/CSVDataSpec.java
+++ b/src/main/java/io/druid/data/input/impl/CSVDataSpec.java
@@ -1,0 +1,78 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.metamx.common.parsers.CSVParser;
+import com.metamx.common.parsers.Parser;
+
+import java.util.List;
+
+/**
+ */
+public class CSVDataSpec implements DataSpec
+{
+  private final List<String> columns;
+  private final List<String> dimensions;
+  private final List<SpatialDimensionSchema> spatialDimensions;
+
+  @JsonCreator
+  public CSVDataSpec(
+      @JsonProperty("columns") List<String> columns,
+      @JsonProperty("dimensions") List<String> dimensions,
+      @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
+  )
+  {
+    Preconditions.checkNotNull(columns, "columns");
+    for (String column : columns) {
+      Preconditions.checkArgument(!column.contains(","), "Column[%s] has a comma, it cannot", column);
+    }
+
+    this.columns = columns;
+    this.dimensions = dimensions;
+    this.spatialDimensions = (spatialDimensions == null)
+                             ? Lists.<SpatialDimensionSchema>newArrayList()
+                             : spatialDimensions;
+  }
+
+  @JsonProperty("columns")
+  public List<String> getColumns()
+  {
+    return columns;
+  }
+
+  @JsonProperty("dimensions")
+  @Override
+  public List<String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  @JsonProperty("spatialDimensions")
+  @Override
+  public List<SpatialDimensionSchema> getSpatialDimensions()
+  {
+    return spatialDimensions;
+  }
+
+  @Override
+  public void verify(List<String> usedCols)
+  {
+    for (String columnName : usedCols) {
+      Preconditions.checkArgument(columns.contains(columnName), "column[%s] not in columns.", columnName);
+    }
+  }
+
+  @Override
+  public boolean hasCustomDimensions()
+  {
+    return !(dimensions == null || dimensions.isEmpty());
+  }
+
+  @Override
+  public Parser<String, Object> getParser()
+  {
+    return new CSVParser(columns);
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/DataSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DataSpec.java
@@ -1,0 +1,28 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.metamx.common.parsers.Parser;
+
+import java.util.List;
+
+/**
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format", defaultImpl = DelimitedDataSpec.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "json", value = JSONDataSpec.class),
+    @JsonSubTypes.Type(name = "csv", value = CSVDataSpec.class),
+    @JsonSubTypes.Type(name = "tsv", value = DelimitedDataSpec.class)
+})
+public interface DataSpec
+{
+  public void verify(List<String> usedCols);
+
+  public boolean hasCustomDimensions();
+
+  public List<String> getDimensions();
+
+  public List<SpatialDimensionSchema> getSpatialDimensions();
+
+  public Parser<String, Object> getParser();
+}

--- a/src/main/java/io/druid/data/input/impl/DelimitedDataSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DelimitedDataSpec.java
@@ -1,0 +1,89 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.metamx.common.parsers.DelimitedParser;
+import com.metamx.common.parsers.Parser;
+
+import java.util.List;
+
+/**
+ */
+public class DelimitedDataSpec implements DataSpec
+{
+  private final String delimiter;
+  private final List<String> columns;
+  private final List<String> dimensions;
+  private final List<SpatialDimensionSchema> spatialDimensions;
+
+  @JsonCreator
+  public DelimitedDataSpec(
+      @JsonProperty("delimiter") String delimiter,
+      @JsonProperty("columns") List<String> columns,
+      @JsonProperty("dimensions") List<String> dimensions,
+      @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
+  )
+  {
+    Preconditions.checkNotNull(columns);
+    for (String column : columns) {
+      Preconditions.checkArgument(!column.contains(","), "Column[%s] has a comma, it cannot", column);
+    }
+
+    this.delimiter = (delimiter == null) ? DelimitedParser.DEFAULT_DELIMITER : delimiter;
+    this.columns = columns;
+    this.dimensions = dimensions;
+    this.spatialDimensions = (spatialDimensions == null)
+                             ? Lists.<SpatialDimensionSchema>newArrayList()
+                             : spatialDimensions;
+  }
+
+  @JsonProperty("delimiter")
+  public String getDelimiter()
+  {
+    return delimiter;
+  }
+
+  @JsonProperty("columns")
+  public List<String> getColumns()
+  {
+    return columns;
+  }
+
+  @JsonProperty("dimensions")
+  @Override
+  public List<String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  @JsonProperty("spatialDimensions")
+  @Override
+  public List<SpatialDimensionSchema> getSpatialDimensions()
+  {
+    return spatialDimensions;
+  }
+
+  @Override
+  public void verify(List<String> usedCols)
+  {
+    for (String columnName : usedCols) {
+      Preconditions.checkArgument(columns.contains(columnName), "column[%s] not in columns.", columnName);
+    }
+  }
+
+  @Override
+  public boolean hasCustomDimensions()
+  {
+    return !(dimensions == null || dimensions.isEmpty());
+  }
+
+  @Override
+  public Parser<String, Object> getParser()
+  {
+    Parser<String, Object> retVal = new DelimitedParser(delimiter);
+    retVal.setFieldNames(columns);
+    return retVal;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/FileIteratingFirehose.java
+++ b/src/main/java/io/druid/data/input/impl/FileIteratingFirehose.java
@@ -1,0 +1,74 @@
+package io.druid.data.input.impl;
+
+import com.google.common.base.Throwables;
+import io.druid.data.input.Firehose;
+import io.druid.data.input.InputRow;
+import io.druid.utils.Runnables;
+import org.apache.commons.io.LineIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ */
+public class FileIteratingFirehose implements Firehose
+{
+  private final Iterator<LineIterator> lineIterators;
+  private final StringInputRowParser parser;
+
+  private LineIterator lineIterator = null;
+
+  public FileIteratingFirehose(
+      Iterator<LineIterator> lineIterators,
+      StringInputRowParser parser
+  )
+  {
+    this.lineIterators = lineIterators;
+    this.parser = parser;
+  }
+
+  @Override
+  public boolean hasMore()
+  {
+    try {
+      return lineIterators.hasNext() || (lineIterator != null && lineIterator.hasNext());
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public InputRow nextRow()
+  {
+    try {
+      if (lineIterator == null || !lineIterator.hasNext()) {
+        // Close old streams, maybe.
+        if (lineIterator != null) {
+          lineIterator.close();
+        }
+
+        lineIterator = lineIterators.next();
+      }
+
+      return parser.parse(lineIterator.next());
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public Runnable commit()
+  {
+    return Runnables.getNoopRunnable();
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (lineIterator != null) {
+      lineIterator.close();
+    }
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/InputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/InputRowParser.java
@@ -1,0 +1,10 @@
+package io.druid.data.input.impl;
+
+import com.metamx.common.exception.FormattedException;
+import io.druid.data.input.InputRow;
+
+public interface InputRowParser<T>
+{
+  public InputRow parse(T input) throws FormattedException;
+  public void addDimensionExclusion(String dimension);
+}

--- a/src/main/java/io/druid/data/input/impl/JSONDataSpec.java
+++ b/src/main/java/io/druid/data/input/impl/JSONDataSpec.java
@@ -1,0 +1,60 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Lists;
+import com.metamx.common.parsers.JSONParser;
+import com.metamx.common.parsers.Parser;
+
+import java.util.List;
+
+/**
+ */
+public class JSONDataSpec implements DataSpec
+{
+  private final List<String> dimensions;
+  private final List<SpatialDimensionSchema> spatialDimensions;
+
+  @JsonCreator
+  public JSONDataSpec(
+      @JsonProperty("dimensions") List<String> dimensions,
+      @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
+  )
+  {
+    this.dimensions = dimensions;
+    this.spatialDimensions = (spatialDimensions == null)
+                             ? Lists.<SpatialDimensionSchema>newArrayList()
+                             : spatialDimensions;
+  }
+
+  @JsonProperty("dimensions")
+  @Override
+  public List<String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  @JsonProperty("spatialDimensions")
+  @Override
+  public List<SpatialDimensionSchema> getSpatialDimensions()
+  {
+    return spatialDimensions;
+  }
+
+  @Override
+  public void verify(List<String> usedCols)
+  {
+  }
+
+  @Override
+  public boolean hasCustomDimensions()
+  {
+    return !(dimensions == null || dimensions.isEmpty());
+  }
+
+  @Override
+  public Parser<String, Object> getParser()
+  {
+    return new JSONParser();
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
@@ -1,0 +1,100 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.metamx.common.exception.FormattedException;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import org.joda.time.DateTime;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MapInputRowParser implements InputRowParser<Map<String, Object>>
+{
+  private final TimestampSpec timestampSpec;
+  private List<String> dimensions;
+  private final Set<String> dimensionExclusions;
+
+  @JsonCreator
+  public MapInputRowParser(
+      @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
+      @JsonProperty("dimensions") List<String> dimensions,
+      @JsonProperty("dimensionExclusions") List<String> dimensionExclusions
+  )
+  {
+    this.timestampSpec = timestampSpec;
+    if (dimensions != null) {
+       this.dimensions = ImmutableList.copyOf(dimensions);
+    }
+    this.dimensionExclusions = Sets.newHashSet();
+    if (dimensionExclusions != null) {
+      for (String dimensionExclusion : dimensionExclusions) {
+        this.dimensionExclusions.add(dimensionExclusion.toLowerCase());
+      }
+    }
+    this.dimensionExclusions.add(timestampSpec.getTimestampColumn().toLowerCase());
+  }
+
+  @Override
+  public InputRow parse(Map<String, Object> theMap) throws FormattedException
+  {
+    final List<String> dimensions = hasCustomDimensions()
+                                    ? this.dimensions
+                                    : Lists.newArrayList(Sets.difference(theMap.keySet(), dimensionExclusions));
+
+    final DateTime timestamp;
+    try {
+      timestamp = timestampSpec.extractTimestamp(theMap);
+      if (timestamp == null) {
+        final String input = theMap.toString();
+        throw new NullPointerException(
+            String.format(
+                "Null timestamp in input: %s",
+                input.length() < 100 ? input : input.substring(0, 100) + "..."
+            )
+        );
+      }
+    }
+    catch (Exception e) {
+      throw new FormattedException.Builder()
+          .withErrorCode(FormattedException.ErrorCode.UNPARSABLE_TIMESTAMP)
+          .withMessage(e.toString())
+          .build();
+    }
+
+    return new MapBasedInputRow(timestamp.getMillis(), dimensions, theMap);
+  }
+
+  private boolean hasCustomDimensions() {
+    return dimensions != null;
+  }
+
+  @Override
+  public void addDimensionExclusion(String dimension)
+  {
+    dimensionExclusions.add(dimension);
+  }
+
+  @JsonProperty
+  public TimestampSpec getTimestampSpec()
+  {
+    return timestampSpec;
+  }
+
+  @JsonProperty
+  public List<String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  @JsonProperty
+  public Set<String> getDimensionExclusions()
+  {
+    return dimensionExclusions;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/SpatialDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/SpatialDimensionSchema.java
@@ -1,0 +1,48 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ */
+public class SpatialDimensionSchema
+{
+  private final String dimName;
+  private final List<String> dims;
+
+  @JsonCreator
+  public SpatialDimensionSchema(
+      @JsonProperty("dimName") String dimName,
+      @JsonProperty("dims") List<String> dims
+  )
+  {
+    this.dimName = dimName.toLowerCase();
+    this.dims = Lists.transform(
+        dims,
+        new Function<String, String>()
+        {
+          @Override
+          public String apply(String input)
+          {
+            return input.toLowerCase();
+          }
+        }
+    );
+  }
+
+  @JsonProperty
+  public String getDimName()
+  {
+    return dimName;
+  }
+
+  @JsonProperty
+  public List<String> getDims()
+  {
+    return dims;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/StringInputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/StringInputRowParser.java
@@ -1,0 +1,120 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.metamx.common.exception.FormattedException;
+import com.metamx.common.parsers.Parser;
+import com.metamx.common.parsers.ToLowerCaseParser;
+import io.druid.data.input.ByteBufferInputRowParser;
+import io.druid.data.input.InputRow;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class StringInputRowParser implements ByteBufferInputRowParser
+{
+	private final MapInputRowParser inputRowCreator;
+	private final Parser<String, Object> parser;
+  private final DataSpec dataSpec;
+
+	private CharBuffer chars = null;
+
+	@JsonCreator
+	public StringInputRowParser(
+	    @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
+	    @JsonProperty("data") DataSpec dataSpec,
+	    @JsonProperty("dimensionExclusions") List<String> dimensionExclusions)
+	{
+    this.dataSpec = dataSpec;
+		this.inputRowCreator = new MapInputRowParser(timestampSpec, dataSpec.getDimensions(), dimensionExclusions);
+		this.parser = new ToLowerCaseParser(dataSpec.getParser());
+	}
+
+	public void addDimensionExclusion(String dimension)
+	{
+		inputRowCreator.addDimensionExclusion(dimension);
+	}
+
+	@Override
+	public InputRow parse(ByteBuffer input) throws FormattedException
+	{
+		return parseMap(buildStringKeyMap(input));
+	}
+
+	private Map<String, Object> buildStringKeyMap(ByteBuffer input)
+	{
+		int payloadSize = input.remaining();
+
+		if (chars == null || chars.remaining() < payloadSize)
+		{
+			chars = CharBuffer.allocate(payloadSize);
+		}
+
+		final CoderResult coderResult = Charsets.UTF_8.newDecoder()
+		    .onMalformedInput(CodingErrorAction.REPLACE)
+		    .onUnmappableCharacter(CodingErrorAction.REPLACE)
+		    .decode(input, chars, true);
+
+		Map<String, Object> theMap;
+		if (coderResult.isUnderflow())
+		{
+			chars.flip();
+			try
+			{
+				theMap = parseString(chars.toString());
+			} finally
+			{
+				chars.clear();
+			}
+		}
+		else
+		{
+			throw new FormattedException.Builder()
+			    .withErrorCode(FormattedException.ErrorCode.UNPARSABLE_ROW)
+			    .withMessage(String.format("Failed with CoderResult[%s]", coderResult))
+			    .build();
+		}
+		return theMap;
+	}
+
+	private Map<String, Object> parseString(String inputString)
+	{
+		return parser.parse(inputString);
+	}
+
+	public InputRow parse(String input) throws FormattedException
+	{
+		return parseMap(parseString(input));
+	}
+
+	private InputRow parseMap(Map<String, Object> theMap)
+	{
+		return inputRowCreator.parse(theMap);
+	}
+
+  @JsonProperty
+  public TimestampSpec getTimestampSpec()
+  {
+    return inputRowCreator.getTimestampSpec();
+  }
+
+  @JsonProperty("data")
+  public DataSpec getDataSpec()
+  {
+    return dataSpec;
+  }
+
+  @JsonProperty
+  public List<String> getDimensionExclusions()
+  {
+    return ImmutableList.copyOf(inputRowCreator.getDimensionExclusions());
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/TimestampSpec.java
+++ b/src/main/java/io/druid/data/input/impl/TimestampSpec.java
@@ -1,0 +1,50 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.metamx.common.parsers.ParserUtils;
+import org.joda.time.DateTime;
+
+import java.util.Map;
+
+/**
+ */
+public class TimestampSpec
+{
+  private static final String defaultFormat = "auto";
+
+  private final String timestampColumn;
+  private final String timestampFormat;
+  private final Function<String, DateTime> timestampConverter;
+
+  @JsonCreator
+  public TimestampSpec(
+      @JsonProperty("column") String timestampColumn,
+      @JsonProperty("format") String format
+  )
+  {
+    this.timestampColumn = timestampColumn;
+    this.timestampFormat = format == null ? defaultFormat : format;
+    this.timestampConverter = ParserUtils.createTimestampParser(timestampFormat);
+  }
+
+  @JsonProperty("column")
+  public String getTimestampColumn()
+  {
+    return timestampColumn;
+  }
+
+  @JsonProperty("format")
+  public String getTimestampFormat()
+  {
+    return timestampFormat;
+  }
+
+  public DateTime extractTimestamp(Map<String, Object> input)
+  {
+    final Object o = input.get(timestampColumn);
+
+    return o == null ? null : timestampConverter.apply(o.toString());
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/ToLowercaseDataSpec.java
+++ b/src/main/java/io/druid/data/input/impl/ToLowercaseDataSpec.java
@@ -1,0 +1,57 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.metamx.common.parsers.Parser;
+import com.metamx.common.parsers.ToLowerCaseParser;
+
+import java.util.List;
+
+/**
+ */
+public class ToLowercaseDataSpec implements DataSpec
+{
+  private final DataSpec delegate;
+
+  public ToLowercaseDataSpec(
+      DataSpec delegate
+  )
+  {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void verify(List<String> usedCols)
+  {
+    delegate.verify(usedCols);
+  }
+
+  @Override
+  public boolean hasCustomDimensions()
+  {
+    return delegate.hasCustomDimensions();
+  }
+
+  @Override
+  public List<String> getDimensions()
+  {
+    return delegate.getDimensions();
+  }
+
+  @Override
+  public List<SpatialDimensionSchema> getSpatialDimensions()
+  {
+    return delegate.getSpatialDimensions();
+  }
+
+  @Override
+  public Parser<String, Object> getParser()
+  {
+    return new ToLowerCaseParser(delegate.getParser());
+  }
+
+  @JsonValue
+  public DataSpec getDelegate()
+  {
+    return delegate;
+  }
+}

--- a/src/main/java/io/druid/guice/Binders.java
+++ b/src/main/java/io/druid/guice/Binders.java
@@ -1,0 +1,34 @@
+package io.druid.guice;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.multibindings.MapBinder;
+import io.druid.segment.loading.DataSegmentKiller;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.DataSegmentPusher;
+import io.druid.tasklogs.TaskLogs;
+
+/**
+ */
+public class Binders
+{
+  public static MapBinder<String, DataSegmentPuller> dataSegmentPullerBinder(Binder binder)
+  {
+    return MapBinder.newMapBinder(binder, String.class, DataSegmentPuller.class);
+  }
+
+  public static MapBinder<String, DataSegmentKiller> dataSegmentKillerBinder(Binder binder)
+  {
+    return MapBinder.newMapBinder(binder, String.class, DataSegmentKiller.class);
+  }
+
+  public static MapBinder<String, DataSegmentPusher> dataSegmentPusherBinder(Binder binder)
+  {
+    return PolyBind.optionBinder(binder, Key.get(DataSegmentPusher.class));
+  }
+
+  public static MapBinder<String, TaskLogs> taskLogsBinder(Binder binder)
+  {
+    return PolyBind.optionBinder(binder, Key.get(TaskLogs.class));
+  }
+}

--- a/src/main/java/io/druid/guice/PolyBind.java
+++ b/src/main/java/io/druid/guice/PolyBind.java
@@ -1,0 +1,138 @@
+package io.druid.guice;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.ProvisionException;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.ScopedBindingBuilder;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.util.Types;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Provides the ability to create "polymorphic" bindings.  Where the polymorphism is actually just making a decision
+ * based on a value in a Properties.
+ *
+ * The workflow is that you first create a choice by calling createChoice().  Then you create options using the binder
+ * returned by the optionBinder() method.  Multiple different modules can call optionBinder and all options will be
+ * reflected at injection time as long as equivalent interface Key objects are passed into the various methods.
+ */
+public class PolyBind
+{
+  /**
+   * Sets up a "choice" for the injector to resolve at injection time.
+   *
+   * @param binder the binder for the injector that is being configured
+   * @param property the property that will be checked to determine the implementation choice
+   * @param interfaceKey the interface that will be injected using this choice
+   * @param defaultKey the default instance to be injected if the property doesn't match a choice.  Can be null
+   * @param <T> interface type
+   * @return A ScopedBindingBuilder so that scopes can be added to the binding, if required.
+   */
+  public static <T> ScopedBindingBuilder createChoice(
+      Binder binder,
+      String property,
+      Key<T> interfaceKey,
+      @Nullable Key<? extends T> defaultKey
+  )
+  {
+    return binder.bind(interfaceKey).toProvider(new ConfiggedProvider<T>(interfaceKey, property, defaultKey));
+  }
+
+  /**
+   * Binds an option for a specific choice.  The choice must already be registered on the injector for this to work.
+   *
+   * @param binder the binder for the injector that is being configured
+   * @param interfaceKey the interface that will have an option added to it.  This must equal the
+   *                     Key provided to createChoice
+   * @param <T> interface type
+   * @return A MapBinder that can be used to create the actual option bindings.
+   */
+  public static <T> MapBinder<String, T> optionBinder(Binder binder, Key<T> interfaceKey)
+  {
+    final TypeLiteral<T> interfaceType = interfaceKey.getTypeLiteral();
+
+    if (interfaceKey.getAnnotation() != null) {
+      return MapBinder.newMapBinder(
+          binder, TypeLiteral.get(String.class), interfaceType, interfaceKey.getAnnotation()
+      );
+    }
+    else if (interfaceKey.getAnnotationType() != null) {
+      return MapBinder.newMapBinder(
+          binder, TypeLiteral.get(String.class), interfaceType, interfaceKey.getAnnotationType()
+      );
+    }
+    else {
+      return MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), interfaceType);
+    }
+  }
+
+  static class ConfiggedProvider<T> implements Provider<T>
+  {
+    private final Key<T> key;
+    private final String property;
+    private final Key<? extends T> defaultKey;
+
+    private Injector injector;
+    private Properties props;
+
+    ConfiggedProvider(
+        Key<T> key,
+        String property,
+        Key<? extends T> defaultKey
+    )
+    {
+      this.key = key;
+      this.property = property;
+      this.defaultKey = defaultKey;
+    }
+
+    @Inject
+    void configure(Injector injector, Properties props)
+    {
+      this.injector = injector;
+      this.props = props;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T get()
+    {
+      final ParameterizedType mapType = Types.mapOf(
+          String.class, Types.newParameterizedType(Provider.class, key.getTypeLiteral().getType())
+      );
+
+      final Map<String, Provider<T>> implsMap;
+      if (key.getAnnotation() != null) {
+        implsMap = (Map<String, Provider<T>>) injector.getInstance(Key.get(mapType, key.getAnnotation()));
+      }
+      else if (key.getAnnotationType() != null) {
+        implsMap = (Map<String, Provider<T>>) injector.getInstance(Key.get(mapType, key.getAnnotation()));
+      }
+      else {
+        implsMap = (Map<String, Provider<T>>) injector.getInstance(Key.get(mapType));
+      }
+
+      final String implName = props.getProperty(property);
+      final Provider<T> provider = implsMap.get(implName);
+
+      if (provider == null) {
+        if (defaultKey == null) {
+          throw new ProvisionException(
+              String.format("Unknown provider[%s] of %s, known options[%s]", implName, key, implsMap.keySet())
+          );
+        }
+        return injector.getInstance(defaultKey);
+      }
+
+      return provider.get();
+    }
+  }
+}

--- a/src/main/java/io/druid/segment/SegmentUtils.java
+++ b/src/main/java/io/druid/segment/SegmentUtils.java
@@ -1,0 +1,29 @@
+package io.druid.segment;
+
+import com.google.common.io.Files;
+import com.google.common.primitives.Ints;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ */
+public class SegmentUtils
+{
+  public static int getVersionFromDir(File inDir) throws IOException
+  {
+    File versionFile = new File(inDir, "version.bin");
+    if (versionFile.exists()) {
+      return Ints.fromByteArray(Files.toByteArray(versionFile));
+    }
+
+    final File indexFile = new File(inDir, "index.drd");
+    int version;
+    try (InputStream in = new FileInputStream(indexFile)) {
+      version = in.read();
+    }
+    return version;
+  }
+}

--- a/src/main/java/io/druid/segment/loading/DataSegmentPusher.java
+++ b/src/main/java/io/druid/segment/loading/DataSegmentPusher.java
@@ -1,22 +1,3 @@
-/*
- * Druid - a distributed column store.
- * Copyright (C) 2012, 2013  Metamarkets Group Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
-
 package io.druid.segment.loading;
 
 import io.druid.timeline.DataSegment;
@@ -26,5 +7,6 @@ import java.io.IOException;
 
 public interface DataSegmentPusher
 {
+  public String getPathForHadoop(String dataSource);
   public DataSegment push(File file, DataSegment segment) throws IOException;
 }

--- a/src/main/java/io/druid/segment/loading/DataSegmentPusherUtil.java
+++ b/src/main/java/io/druid/segment/loading/DataSegmentPusherUtil.java
@@ -1,0 +1,44 @@
+package io.druid.segment.loading;
+
+import com.google.common.base.Joiner;
+import io.druid.timeline.DataSegment;
+import org.joda.time.format.ISODateTimeFormat;
+
+/**
+ */
+public class DataSegmentPusherUtil
+{
+	private static final Joiner JOINER = Joiner.on("/").skipNulls();
+
+	public static String getStorageDir(DataSegment segment)
+	{
+		return JOINER.join(
+		    segment.getDataSource(),
+		    String.format(
+		        "%s_%s",
+		        segment.getInterval().getStart(),
+            segment.getInterval().getEnd()
+        ),
+        segment.getVersion(),
+        segment.getShardSpec().getPartitionNum()
+    );
+  }
+
+	/**
+	 * Due to https://issues.apache.org/jira/browse/HDFS-13 ":" are not allowed in
+	 * path names. So we format paths differently for HDFS.
+	 */
+	public static String getHdfsStorageDir(DataSegment segment)
+	{
+		return JOINER.join(
+		    segment.getDataSource(),
+		    String.format(
+		        "%s_%s",
+		        segment.getInterval().getStart().toString(ISODateTimeFormat.basicDateTime()),
+		        segment.getInterval().getEnd().toString(ISODateTimeFormat.basicDateTime())
+		        ),
+		    segment.getVersion().replaceAll(":", "_"),
+		    segment.getShardSpec().getPartitionNum()
+		    );
+	}
+}

--- a/src/main/java/io/druid/tasklogs/NoopTaskLogs.java
+++ b/src/main/java/io/druid/tasklogs/NoopTaskLogs.java
@@ -1,0 +1,26 @@
+package io.druid.tasklogs;
+
+import com.google.common.base.Optional;
+import com.google.common.io.InputSupplier;
+import com.metamx.common.logger.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class NoopTaskLogs implements TaskLogs
+{
+  private final Logger log = new Logger(TaskLogs.class);
+
+  @Override
+  public Optional<InputSupplier<InputStream>> streamTaskLog(String taskid, long offset) throws IOException
+  {
+    return Optional.absent();
+  }
+
+  @Override
+  public void pushTaskLog(String taskid, File logFile) throws IOException
+  {
+    log.info("Not pushing logs for task: %s", taskid);
+  }
+}

--- a/src/main/java/io/druid/tasklogs/TaskLogPusher.java
+++ b/src/main/java/io/druid/tasklogs/TaskLogPusher.java
@@ -1,0 +1,12 @@
+package io.druid.tasklogs;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Something that knows how to persist local task logs to some form of long-term storage.
+ */
+public interface TaskLogPusher
+{
+  public void pushTaskLog(String taskid, File logFile) throws IOException;
+}

--- a/src/main/java/io/druid/tasklogs/TaskLogStreamer.java
+++ b/src/main/java/io/druid/tasklogs/TaskLogStreamer.java
@@ -1,0 +1,23 @@
+package io.druid.tasklogs;
+
+import com.google.common.base.Optional;
+import com.google.common.io.InputSupplier;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Something that knows how to stream logs for tasks.
+ */
+public interface TaskLogStreamer
+{
+  /**
+   * Stream log for a task.
+   *
+   * @param offset If zero, stream the entire log. If positive, attempt to read from this position onwards. If
+   *               negative, attempt to read this many bytes from the end of the file (like <tt>tail -n</tt>).
+   *
+   * @return input supplier for this log, if available from this provider
+   */
+  public Optional<InputSupplier<InputStream>> streamTaskLog(String taskid, long offset) throws IOException;
+}

--- a/src/main/java/io/druid/tasklogs/TaskLogs.java
+++ b/src/main/java/io/druid/tasklogs/TaskLogs.java
@@ -1,0 +1,5 @@
+package io.druid.tasklogs;
+
+public interface TaskLogs extends TaskLogStreamer, TaskLogPusher
+{
+}

--- a/src/main/java/io/druid/utils/CompressionUtils.java
+++ b/src/main/java/io/druid/utils/CompressionUtils.java
@@ -1,0 +1,123 @@
+package io.druid.utils;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closeables;
+import com.google.common.io.Files;
+import com.metamx.common.ISE;
+import com.metamx.common.StreamUtils;
+import com.metamx.common.logger.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ */
+public class CompressionUtils
+{
+  private static final Logger log = new Logger(CompressionUtils.class);
+
+  public static long zip(File directory, File outputZipFile) throws IOException
+  {
+    if (!outputZipFile.getName().endsWith(".zip")) {
+      log.warn("No .zip suffix[%s], putting files from [%s] into it anyway.", outputZipFile, directory);
+    }
+
+    final FileOutputStream out = new FileOutputStream(outputZipFile);
+    try {
+      final long retVal = zip(directory, out);
+
+      out.close();
+
+      return retVal;
+    }
+    finally {
+      Closeables.closeQuietly(out);
+    }
+  }
+
+  public static long zip(File directory, OutputStream out) throws IOException
+  {
+    if (!directory.isDirectory()) {
+      throw new IOException(String.format("directory[%s] is not a directory", directory));
+    }
+
+    long totalSize = 0;
+    ZipOutputStream zipOut = null;
+    try {
+      zipOut = new ZipOutputStream(out);
+      File[] files = directory.listFiles();
+      for (File file : files) {
+        log.info("Adding file[%s] with size[%,d].  Total size so far[%,d]", file, file.length(), totalSize);
+        if (file.length() >= Integer.MAX_VALUE) {
+          zipOut.finish();
+          throw new IOException(String.format("file[%s] too large [%,d]", file, file.length()));
+        }
+        zipOut.putNextEntry(new ZipEntry(file.getName()));
+        totalSize += ByteStreams.copy(Files.newInputStreamSupplier(file), zipOut);
+      }
+      zipOut.closeEntry();
+    }
+    finally {
+      if (zipOut != null) {
+        zipOut.finish();
+      }
+    }
+
+    return totalSize;
+  }
+
+  public static void unzip(File pulledFile, File outDir) throws IOException
+  {
+    if (!(outDir.exists() && outDir.isDirectory())) {
+      throw new ISE("outDir[%s] must exist and be a directory", outDir);
+    }
+
+    log.info("Unzipping file[%s] to [%s]", pulledFile, outDir);
+    InputStream in = null;
+    try {
+      in = new BufferedInputStream(new FileInputStream(pulledFile));
+      unzip(in, outDir);
+    }
+    finally {
+      Closeables.closeQuietly(in);
+    }
+  }
+
+  public static void unzip(InputStream in, File outDir) throws IOException
+  {
+    ZipInputStream zipIn = new ZipInputStream(in);
+
+    ZipEntry entry;
+    while ((entry = zipIn.getNextEntry()) != null) {
+      FileOutputStream out = null;
+      try {
+        out = new FileOutputStream(new File(outDir, entry.getName()));
+        ByteStreams.copy(zipIn, out);
+        zipIn.closeEntry();
+        out.close();
+      }
+      finally {
+        Closeables.closeQuietly(out);
+      }
+    }
+  }
+
+  public static void gunzip(File pulledFile, File outDir) throws IOException
+  {
+    log.info("Gunzipping file[%s] to [%s]", pulledFile, outDir);
+    StreamUtils.copyToFileAndClose(new GZIPInputStream(new FileInputStream(pulledFile)), outDir);
+    if (!pulledFile.delete()) {
+      log.error("Could not delete tmpFile[%s].", pulledFile);
+    }
+  }
+
+}

--- a/src/main/java/io/druid/utils/Runnables.java
+++ b/src/main/java/io/druid/utils/Runnables.java
@@ -1,0 +1,12 @@
+package io.druid.utils;
+
+/**
+ */
+public class Runnables
+{
+  public static Runnable getNoopRunnable(){
+    return new Runnable(){
+      public void run(){}
+    };
+  }
+}

--- a/src/test/java/io/druid/TestObjectMapper.java
+++ b/src/test/java/io/druid/TestObjectMapper.java
@@ -1,0 +1,21 @@
+package io.druid;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ */
+public class TestObjectMapper extends ObjectMapper
+{
+  public TestObjectMapper()
+  {
+    configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+    configure(MapperFeature.AUTO_DETECT_FIELDS, false);
+    configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
+    configure(MapperFeature.AUTO_DETECT_SETTERS, false);
+    configure(SerializationFeature.INDENT_OUTPUT, false);
+  }
+}

--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -1,0 +1,70 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.druid.TestObjectMapper;
+import io.druid.data.input.ByteBufferInputRowParser;
+import io.druid.data.input.InputRow;
+import junit.framework.Assert;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class InputRowParserSerdeTest
+{
+  private final ObjectMapper jsonMapper = new TestObjectMapper();
+
+  @Test
+  public void testStringInputRowParserSerde() throws Exception
+  {
+    final StringInputRowParser parser = new StringInputRowParser(
+        new TimestampSpec("timestamp", "iso"),
+        new JSONDataSpec(
+            ImmutableList.of("foo", "bar"), ImmutableList.<SpatialDimensionSchema>of()
+        ),
+        ImmutableList.of("baz")
+    );
+    final ByteBufferInputRowParser parser2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsBytes(parser),
+        ByteBufferInputRowParser.class
+    );
+    final InputRow parsed = parser2.parse(
+        ByteBuffer.wrap(
+            "{\"foo\":\"x\",\"bar\":\"y\",\"qux\":\"z\",\"timestamp\":\"2000\"}".getBytes(Charsets.UTF_8)
+        )
+    );
+    Assert.assertEquals(ImmutableList.of("foo", "bar"), parsed.getDimensions());
+    Assert.assertEquals(ImmutableList.of("x"), parsed.getDimension("foo"));
+    Assert.assertEquals(ImmutableList.of("y"), parsed.getDimension("bar"));
+    Assert.assertEquals(new DateTime("2000").getMillis(), parsed.getTimestampFromEpoch());
+  }
+
+  @Test
+  public void testMapInputRowParserSerde() throws Exception
+  {
+    final MapInputRowParser parser = new MapInputRowParser(
+        new TimestampSpec("timestamp", "iso"),
+        ImmutableList.of("foo", "bar"),
+        ImmutableList.of("baz")
+    );
+    final MapInputRowParser parser2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsBytes(parser),
+        MapInputRowParser.class
+    );
+    final InputRow parsed = parser2.parse(
+        ImmutableMap.<String, Object>of(
+            "foo", "x",
+            "bar", "y",
+            "qux", "z",
+            "timestamp", "2000"
+        )
+    );
+    Assert.assertEquals(ImmutableList.of("foo", "bar"), parsed.getDimensions());
+    Assert.assertEquals(ImmutableList.of("x"), parsed.getDimension("foo"));
+    Assert.assertEquals(ImmutableList.of("y"), parsed.getDimension("bar"));
+    Assert.assertEquals(new DateTime("2000").getMillis(), parsed.getTimestampFromEpoch());
+  }
+}

--- a/src/test/java/io/druid/guice/PolyBindTest.java
+++ b/src/test/java/io/druid/guice/PolyBindTest.java
@@ -1,0 +1,109 @@
+package io.druid.guice;
+
+import com.google.common.collect.Iterables;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Names;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+/**
+ */
+public class PolyBindTest
+{
+  private Properties props;
+  private Injector injector;
+
+  public void setUp(Module... modules) throws Exception
+  {
+    props = new Properties();
+    injector = Guice.createInjector(
+        Iterables.concat(
+            Arrays.asList(
+                new Module()
+                {
+                  @Override
+                  public void configure(Binder binder)
+                  {
+                    binder.bind(Properties.class).toInstance(props);
+                    PolyBind.createChoice(binder, "billy", Key.get(Gogo.class), Key.get(GoA.class));
+                  }
+                }
+            ),
+            Arrays.asList(modules)
+        )
+    );
+  }
+
+  @Test
+  public void testSanity() throws Exception
+  {
+    setUp(
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            final MapBinder<String,Gogo> gogoBinder = PolyBind.optionBinder(binder, Key.get(Gogo.class));
+            gogoBinder.addBinding("a").to(GoA.class);
+            gogoBinder.addBinding("b").to(GoB.class);
+
+            PolyBind.createChoice(
+                binder, "billy", Key.get(Gogo.class, Names.named("reverse")), Key.get(GoB.class)
+            );
+            final MapBinder<String,Gogo> annotatedGogoBinder = PolyBind.optionBinder(
+                binder, Key.get(Gogo.class, Names.named("reverse"))
+            );
+            annotatedGogoBinder.addBinding("a").to(GoB.class);
+            annotatedGogoBinder.addBinding("b").to(GoA.class);
+          }
+        }
+    );
+
+
+    Assert.assertEquals("A", injector.getInstance(Gogo.class).go());
+    Assert.assertEquals("B", injector.getInstance(Key.get(Gogo.class, Names.named("reverse"))).go());
+    props.setProperty("billy", "b");
+    Assert.assertEquals("B", injector.getInstance(Gogo.class).go());
+    Assert.assertEquals("A", injector.getInstance(Key.get(Gogo.class, Names.named("reverse"))).go());
+    props.setProperty("billy", "a");
+    Assert.assertEquals("A", injector.getInstance(Gogo.class).go());
+    Assert.assertEquals("B", injector.getInstance(Key.get(Gogo.class, Names.named("reverse"))).go());
+    props.setProperty("billy", "b");
+    Assert.assertEquals("B", injector.getInstance(Gogo.class).go());
+    Assert.assertEquals("A", injector.getInstance(Key.get(Gogo.class, Names.named("reverse"))).go());
+    props.setProperty("billy", "c");
+    Assert.assertEquals("A", injector.getInstance(Gogo.class).go());
+    Assert.assertEquals("B", injector.getInstance(Key.get(Gogo.class, Names.named("reverse"))).go());
+  }
+
+  public static interface Gogo
+  {
+    public String go();
+  }
+
+  public static class GoA implements Gogo
+  {
+    @Override
+    public String go()
+    {
+      return "A";
+    }
+  }
+
+  public static class GoB implements Gogo
+  {
+    @Override
+    public String go()
+    {
+      return "B";
+    }
+  }
+}

--- a/src/test/java/io/druid/segment/loading/DataSegmentPusherUtilTest.java
+++ b/src/test/java/io/druid/segment/loading/DataSegmentPusherUtilTest.java
@@ -1,0 +1,36 @@
+package io.druid.segment.loading;
+
+import com.google.common.collect.ImmutableMap;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class DataSegmentPusherUtilTest
+{
+    @Test
+    public void shouldNotHaveColonsInHdfsStorageDir() throws Exception {
+
+        Interval interval = new Interval("2011-10-01/2011-10-02");
+        ImmutableMap<String, Object> loadSpec = ImmutableMap.<String, Object>of("something", "or_other");
+
+        DataSegment segment = new DataSegment(
+                "something",
+                interval,
+                "brand:new:version",
+                loadSpec,
+                Arrays.asList("dim1", "dim2"),
+                Arrays.asList("met1", "met2"),
+                new NoneShardSpec(),
+                null,
+                1
+        );
+
+        String storageDir = DataSegmentPusherUtil.getHdfsStorageDir(segment);
+        Assert.assertEquals("something/20111001T000000.000Z_20111002T000000.000Z/brand_new_version/0", storageDir);
+
+    }
+}


### PR DESCRIPTION
This change set moves some files from Druid into druid-api in order to allow for the implementation of storage and firehose extensions without depending on Druid proper.

Note, this does imply a re-licensing of the various files added, but I felt that it was important to be able to extend without having to pull all of Druid into the extension (and fight with the resultant versioning issues)
