### PR TITLE
Add getRaw to Row input to allow dimensions with complex storage types

### DIFF
--- a/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -71,6 +71,11 @@ public class MapBasedRow implements Row
   }
 
   @Override
+  public Object getRaw(String dimension) {
+    return event.get(dimension);
+  }
+
+  @Override
   public float getFloatMetric(String metric)
   {
     Object metricValue = event.get(metric);

--- a/src/main/java/io/druid/data/input/Row.java
+++ b/src/main/java/io/druid/data/input/Row.java
@@ -41,7 +41,15 @@ public interface Row
    */
   public List<String> getDimension(String dimension);
 
-  /**
+   /**
+   * Returns the raw dimension value for the given column name. This is different from #getDimension which
+   * all values to strings before returning them.
+   * @param dimension the lowercase column name of the dimension requested
+   * @return the value of the provided column name
+   */
+   public Object getRaw(String dimension);
+
+    /**
    * Returns the float value of the given metric column.
    *
    * Column names are always all lowercase in order to support case-insensitive schemas.


### PR DESCRIPTION
Allow extracting the raw data from Rows to enable aggregators with non-string values (as discussed with @cheddar).
