### PR TITLE
Add hash and equals for an abstract implementation of CliCommandCreator and DruidModule

### DIFF
--- a/src/main/java/io/druid/cli/AbstractCliCommandCreator.java
+++ b/src/main/java/io/druid/cli/AbstractCliCommandCreator.java
@@ -1,0 +1,20 @@
+package io.druid.cli;
+
+/**
+ *
+ */
+public abstract class AbstractCliCommandCreator implements CliCommandCreator
+{
+  // These are to make sure command creators shoved into a hash set are unique on class rather than instance.
+  @Override
+  public int hashCode(){
+    return getClass().getCanonicalName().hashCode();
+  }
+  @Override
+  public boolean equals(Object other){
+    if(null == other){
+      return false;
+    }
+    return other.getClass().equals(getClass());
+  }
+}

--- a/src/main/java/io/druid/initialization/AbstractDruidModule.java
+++ b/src/main/java/io/druid/initialization/AbstractDruidModule.java
@@ -1,0 +1,20 @@
+package io.druid.initialization;
+
+/**
+ *
+ */
+public abstract class AbstractDruidModule implements DruidModule
+{
+  // These are to make sure modules shoved into a hash set are unique on class rather than instance.
+  @Override
+  public int hashCode(){
+    return getClass().getCanonicalName().hashCode();
+  }
+  @Override
+  public boolean equals(Object other){
+    if(null == other){
+      return false;
+    }
+    return other.getClass().equals(getClass());
+  }
+}


### PR DESCRIPTION
This is to allow hash maps or hash sets to have only one instance of these particular classes. The usage of the abstract version is completely optional. These would probably be well served by Java 8's interface with default method stuff.