### PR TITLE
Add URI Handlers and LoadSpec. Deprecate CompressionUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.metamx</groupId>
             <artifactId>java-util</artifactId>
-            <version>0.26.14</version>
+            <version>0.27.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/druid/segment/loading/DataSegmentPuller.java
+++ b/src/main/java/io/druid/segment/loading/DataSegmentPuller.java
@@ -5,6 +5,7 @@ import io.druid.timeline.DataSegment;
 import java.io.File;
 
 /**
+ * A DataSegmentPuller is responsible for pulling data for a particular segment into a particular directory
  */
 public interface DataSegmentPuller
 {
@@ -12,7 +13,8 @@ public interface DataSegmentPuller
    * Pull down segment files for the given DataSegment and put them in the given directory.
    *
    * @param segment The segment to pull down files for
-   * @param dir The directory to store the files in
+   * @param dir     The directory to store the files in
+   *
    * @throws SegmentLoadingException if there are any errors
    */
   public void getSegmentFiles(DataSegment segment, File dir) throws SegmentLoadingException;

--- a/src/main/java/io/druid/segment/loading/LoadSpec.java
+++ b/src/main/java/io/druid/segment/loading/LoadSpec.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Metamarkets Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.segment.loading;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.File;
+
+/**
+ * A means of pulling segment files into a destination directory
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface LoadSpec
+{
+  /**
+   * Method should put the segment files in the directory passed
+   * @param destDir The destination directory
+   * @return The byte count of data put in the destination directory
+   */
+  public LoadSpecResult loadSegment(File destDir) throws SegmentLoadingException;
+
+  // Hold interesting data about the results of the segment load
+  public static class LoadSpecResult{
+    private final long size;
+    public LoadSpecResult(long size){
+      this.size = size;
+    }
+    public long getSize(){
+      return this.size;
+    }
+  }
+}

--- a/src/main/java/io/druid/segment/loading/URIDataPuller.java
+++ b/src/main/java/io/druid/segment/loading/URIDataPuller.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 Metamarkets Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.segment.loading;
+
+import com.google.common.base.Predicate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * A URIDataPuller has handlings for URI based data
+ */
+public interface URIDataPuller
+{
+  /**
+   * Create a new InputStream based on the URI
+   *
+   * @param uri The URI to open an Input Stream to
+   *
+   * @return A new InputStream which streams the URI in question
+   *
+   * @throws IOException
+   */
+  public InputStream getInputStream(URI uri) throws IOException;
+
+  /**
+   * Returns an abstract "version" for the URI. The exact meaning of the version is left up to the implementation.
+   *
+   * @param uri The URI to check
+   *
+   * @return A "version" as interpreted by the URIDataPuller implementation
+   *
+   * @throws IOException on error
+   */
+  public String getVersion(URI uri) throws IOException;
+
+  /**
+   * Evaluates a Throwable to see if it is recoverable. This is expected to be used in conjunction with the other methods
+   * to determine if anything thrown from the method should be retried.
+   *
+   * @return Predicate function indicating if the Throwable is recoverable
+   */
+  public Predicate<Throwable> shouldRetryPredicate();
+}

--- a/src/main/java/io/druid/timeline/DataSegment.java
+++ b/src/main/java/io/druid/timeline/DataSegment.java
@@ -78,6 +78,7 @@ public class DataSegment implements Comparable<DataSegment>
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("interval") Interval interval,
       @JsonProperty("version") String version,
+      // use `Map` *NOT* `LoadSpec` because we want to do lazy materialization to prevent dependency pollution
       @JsonProperty("loadSpec") Map<String, Object> loadSpec,
       @JsonProperty("dimensions") @JsonDeserialize(using = CommaListJoinDeserializer.class) List<String> dimensions,
       @JsonProperty("metrics") @JsonDeserialize(using = CommaListJoinDeserializer.class) List<String> metrics,

--- a/src/main/java/io/druid/utils/CompressionUtils.java
+++ b/src/main/java/io/druid/utils/CompressionUtils.java
@@ -1,24 +1,11 @@
 package io.druid.utils;
 
-import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
-import com.google.common.io.Files;
-import com.metamx.common.ISE;
-import com.metamx.common.StreamUtils;
-import com.metamx.common.guava.CloseQuietly;
 import com.metamx.common.logger.Logger;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
 
 /**
  */
@@ -26,82 +13,47 @@ public class CompressionUtils
 {
   private static final Logger log = new Logger(CompressionUtils.class);
 
+
+  @Deprecated // Use com.metamx.common.CompressionUtils.zip
   public static long zip(File directory, File outputZipFile) throws IOException
   {
-    if (!outputZipFile.getName().endsWith(".zip")) {
-      log.warn("No .zip suffix[%s], putting files from [%s] into it anyway.", outputZipFile, directory);
-    }
-
-    try (final FileOutputStream out = new FileOutputStream(outputZipFile)) {
-      return zip(directory, out);
-    }
+    return com.metamx.common.CompressionUtils.zip(directory, outputZipFile);
   }
 
+
+  @Deprecated // Use com.metamx.common.CompressionUtils.zip
   public static long zip(File directory, OutputStream out) throws IOException
   {
-    if (!directory.isDirectory()) {
-      throw new IOException(String.format("directory[%s] is not a directory", directory));
-    }
-
-    long totalSize = 0;
-    ZipOutputStream zipOut = null;
-    try {
-      zipOut = new ZipOutputStream(out);
-      File[] files = directory.listFiles();
-      for (File file : files) {
-        log.info("Adding file[%s] with size[%,d].  Total size so far[%,d]", file, file.length(), totalSize);
-        if (file.length() >= Integer.MAX_VALUE) {
-          zipOut.finish();
-          throw new IOException(String.format("file[%s] too large [%,d]", file, file.length()));
-        }
-        zipOut.putNextEntry(new ZipEntry(file.getName()));
-        totalSize += ByteStreams.copy(Files.newInputStreamSupplier(file), zipOut);
-      }
-      zipOut.closeEntry();
-    }
-    finally {
-      if (zipOut != null) {
-        zipOut.finish();
-      }
-    }
-
-    return totalSize;
+    return com.metamx.common.CompressionUtils.zip(directory, out);
   }
 
+  @Deprecated // Use com.metamx.common.CompressionUtils.unzip
   public static void unzip(File pulledFile, File outDir) throws IOException
   {
-    if (!(outDir.exists() && outDir.isDirectory())) {
-      throw new ISE("outDir[%s] must exist and be a directory", outDir);
-    }
-
-    log.info("Unzipping file[%s] to [%s]", pulledFile, outDir);
-    InputStream in = null;
-    try {
-      in = new BufferedInputStream(new FileInputStream(pulledFile));
-      unzip(in, outDir);
-    }
-    finally {
-      CloseQuietly.close(in);
-    }
+    com.metamx.common.CompressionUtils.unzip(pulledFile, outDir);
   }
 
+  @Deprecated // Use com.metamx.common.CompressionUtils.unzip
   public static void unzip(InputStream in, File outDir) throws IOException
   {
-    ZipInputStream zipIn = new ZipInputStream(in);
-
-    ZipEntry entry;
-    while ((entry = zipIn.getNextEntry()) != null) {
-      try (FileOutputStream out = new FileOutputStream(new File(outDir, entry.getName()))){
-        ByteStreams.copy(zipIn, out);
-        zipIn.closeEntry();
-      }
-    }
+    com.metamx.common.CompressionUtils.unzip(in, outDir);
   }
 
+  /**
+   * Uncompress using a gzip uncompress algorithm from the `pulledFile` to the `outDir`.
+   * Unlike `com.metamx.common.CompressionUtils.gunzip`, this function takes an output *DIRECTORY* and tries to guess the file name.
+   * It is recommended that the caller use `com.metamx.common.CompressionUtils.gunzip` and specify the output file themselves to ensure names are as expected
+   *
+   * @param pulledFile The source file
+   * @param outDir     The destination directory to put the resulting file
+   *
+   * @throws IOException on propogated IO exception, IAE if it cannot determine the proper new name for `pulledFile`
+   */
+  @Deprecated // See description for alternative
   public static void gunzip(File pulledFile, File outDir) throws IOException
   {
-    log.info("Gunzipping file[%s] to [%s]", pulledFile, outDir);
-    StreamUtils.copyToFileAndClose(new GZIPInputStream(new FileInputStream(pulledFile)), outDir);
+    final File outFile = new File(outDir, com.metamx.common.CompressionUtils.getGzBaseName(pulledFile.getName()));
+    com.metamx.common.CompressionUtils.gunzip(pulledFile, outFile);
     if (!pulledFile.delete()) {
       log.error("Could not delete tmpFile[%s].", pulledFile);
     }


### PR DESCRIPTION
Adds `URIDataPuller` interface for dealing with URI data. I also have a patch incoming to Druid that implements this update.

Also adds a `LoadSpec` to help solidify the loading of segment data.

Also move `CompressionUtils` to java-util via https://github.com/metamx/java-util/pull/22