### PR TITLE
backward compatibility fix for long metric parsing

### DIFF
--- a/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -126,7 +126,8 @@ public class MapBasedRow implements Row
       return ((Number) metricValue).longValue();
     } else if (metricValue instanceof String) {
       try {
-        return Long.valueOf(((String) metricValue).replace(",", ""));
+        String s = ((String) metricValue).replace(",", "");
+        return s.contains(".") ? Math.round(Double.valueOf(s)) : Long.valueOf(s);
       }
       catch (Exception e) {
         throw new ParseException(e, "Unable to parse metrics[%s], value[%s]", metric, metricValue);

--- a/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -127,7 +127,7 @@ public class MapBasedRow implements Row
     } else if (metricValue instanceof String) {
       try {
         String s = ((String) metricValue).replace(",", "");
-        return s.contains(".") ? Math.round(Double.valueOf(s)) : Long.valueOf(s);
+        return s.contains(".") ? Double.valueOf(s).longValue() : Long.valueOf(s);
       }
       catch (Exception e) {
         throw new ParseException(e, "Unable to parse metrics[%s], value[%s]", metric, metricValue);

--- a/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -12,6 +12,7 @@ import org.joda.time.DateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  */
@@ -21,6 +22,8 @@ public class MapBasedRow implements Row
 
   private final DateTime timestamp;
   private final Map<String, Object> event;
+
+  private static final Pattern LONG_PAT = Pattern.compile("[-|+]?\\d+");
 
   @JsonCreator
   public MapBasedRow(
@@ -127,7 +130,7 @@ public class MapBasedRow implements Row
     } else if (metricValue instanceof String) {
       try {
         String s = ((String) metricValue).replace(",", "");
-        return s.contains(".") ? Double.valueOf(s).longValue() : Long.valueOf(s);
+        return LONG_PAT.matcher(s).matches() ? Long.valueOf(s) : Double.valueOf(s).longValue();
       }
       catch (Exception e) {
         throw new ParseException(e, "Unable to parse metrics[%s], value[%s]", metric, metricValue);

--- a/src/test/java/io/druid/data/input/MapBasedRowTest.java
+++ b/src/test/java/io/druid/data/input/MapBasedRowTest.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input;
+
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MapBasedRowTest
+{
+  @Test
+  public void testGetLongMetricFromString()
+  {
+    MapBasedRow row = new MapBasedRow(
+        new DateTime(),
+        ImmutableMap.<String, Object>of(
+            "k0", "-1.2", "k1", "1.23", "k2", "1.8", "k3", "9223372036854775806", "k4", "-9223372036854775807")
+    );
+    Assert.assertEquals(-1, row.getLongMetric("k0"));
+    Assert.assertEquals(1, row.getLongMetric("k1"));
+    Assert.assertEquals(2, row.getLongMetric("k2"));
+    Assert.assertEquals(9223372036854775806L, row.getLongMetric("k3"));
+    Assert.assertEquals(-9223372036854775807L, row.getLongMetric("k4"));
+  }
+}

--- a/src/test/java/io/druid/data/input/MapBasedRowTest.java
+++ b/src/test/java/io/druid/data/input/MapBasedRowTest.java
@@ -37,7 +37,7 @@ public class MapBasedRowTest
     );
     Assert.assertEquals(-1, row.getLongMetric("k0"));
     Assert.assertEquals(1, row.getLongMetric("k1"));
-    Assert.assertEquals(2, row.getLongMetric("k2"));
+    Assert.assertEquals(1, row.getLongMetric("k2"));
     Assert.assertEquals(9223372036854775806L, row.getLongMetric("k3"));
     Assert.assertEquals(-9223372036854775807L, row.getLongMetric("k4"));
   }

--- a/src/test/java/io/druid/data/input/MapBasedRowTest.java
+++ b/src/test/java/io/druid/data/input/MapBasedRowTest.java
@@ -32,13 +32,23 @@ public class MapBasedRowTest
   {
     MapBasedRow row = new MapBasedRow(
         new DateTime(),
-        ImmutableMap.<String, Object>of(
-            "k0", "-1.2", "k1", "1.23", "k2", "1.8", "k3", "9223372036854775806", "k4", "-9223372036854775807")
+        ImmutableMap.<String,Object>builder()
+          .put("k0", "-1.2")
+          .put("k1", "1.23")
+          .put("k2", "1.8")
+          .put("k3", "1e5")
+          .put("k4", "9223372036854775806")
+          .put("k5", "-9223372036854775807")
+          .put("k6", "+9223372036854775802")
+          .build()
     );
+    
     Assert.assertEquals(-1, row.getLongMetric("k0"));
     Assert.assertEquals(1, row.getLongMetric("k1"));
     Assert.assertEquals(1, row.getLongMetric("k2"));
-    Assert.assertEquals(9223372036854775806L, row.getLongMetric("k3"));
-    Assert.assertEquals(-9223372036854775807L, row.getLongMetric("k4"));
+    Assert.assertEquals(100000, row.getLongMetric("k3"));
+    Assert.assertEquals(9223372036854775806L, row.getLongMetric("k4"));
+    Assert.assertEquals(-9223372036854775807L, row.getLongMetric("k5"));
+    Assert.assertEquals(9223372036854775802L, row.getLongMetric("k6"));
   }
 }


### PR DESCRIPTION
This patch fixes the backward compatibility issue described below.

With 0.6.x, it was allowed to have "6.0" in the input data but have it ingested inside a "longsum" metric. currently, in 0.7.0, same ingestion fails with following exception .

ERROR [io.druid.indexing.overlord.ThreadPoolTaskRunner] Exception while running task[IndexTask{...}]
com.metamx.common.parsers.ParseException: Unable to parse metrics[timespent], value[6.0]
	at io.druid.data.input.MapBasedRow.getLongMetric(MapBasedRow.java:132)
	at io.druid.segment.incremental.IncrementalIndex$1$2.get(IncrementalIndex.java:97)
	at io.druid.query.aggregation.LongSumAggregator.aggregate(LongSumAggregator.java:58)
	at io.druid.segment.incremental.OnheapIncrementalIndex.addToFacts(OnheapIncrementalIndex.java:169)
	at io.druid.segment.incremental.IncrementalIndex.add(IncrementalIndex.java:431)
	at io.druid.segment.realtime.plumber.Sink.add(Sink.java:125)
	at io.druid.indexing.common.index.YeOldePlumberSchool$1.add(YeOldePlumberSchool.java:115)
	at io.druid.indexing.common.task.IndexTask.generateSegment(IndexTask.java:346)
	at io.druid.indexing.common.task.IndexTask.run(IndexTask.java:185)
        ......
Caused by: java.lang.NumberFormatException: For input string: "6.0"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:441)
	at java.lang.Long.valueOf(Long.java:540)
	at io.druid.data.input.MapBasedRow.getLongMetric(MapBasedRow.java:129)
	... 