### PR TITLE
Add an option to fill out a default value when the data has no timestamp...

### DIFF
--- a/src/main/java/io/druid/data/input/impl/TimestampSpec.java
+++ b/src/main/java/io/druid/data/input/impl/TimestampSpec.java
@@ -3,8 +3,6 @@ package io.druid.data.input.impl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
-import com.metamx.common.parsers.ParseException;
 import com.metamx.common.parsers.ParserUtils;
 import org.joda.time.DateTime;
 
@@ -14,22 +12,30 @@ import java.util.Map;
  */
 public class TimestampSpec
 {
-  private static final String defaultColumn = "timestamp";
-  private static final String defaultFormat = "auto";
+  private static final String DEFAULT_COLUMN = "timestamp";
+  private static final String DEFAULT_FORMAT = "auto";
+  private static final DateTime MISSING_VALUE = null;
 
   private final String timestampColumn;
   private final String timestampFormat;
   private final Function<String, DateTime> timestampConverter;
+  // this value should never be set for production data
+  private final DateTime missingValue;
 
   @JsonCreator
   public TimestampSpec(
       @JsonProperty("column") String timestampColumn,
-      @JsonProperty("format") String format
+      @JsonProperty("format") String format,
+      // this value should never be set for production data
+      @JsonProperty("missingValue") DateTime missingValue
   )
   {
-    this.timestampColumn = (timestampColumn == null) ? defaultColumn : timestampColumn;
-    this.timestampFormat = format == null ? defaultFormat : format;
+    this.timestampColumn = (timestampColumn == null) ? DEFAULT_COLUMN : timestampColumn;
+    this.timestampFormat = format == null ? DEFAULT_FORMAT : format;
     this.timestampConverter = ParserUtils.createTimestampParser(timestampFormat);
+    this.missingValue = missingValue == null
+                                       ? MISSING_VALUE
+                                       : missingValue;
   }
 
   @JsonProperty("column")
@@ -48,6 +54,6 @@ public class TimestampSpec
   {
     final Object o = input.get(timestampColumn);
 
-    return o == null ? null : timestampConverter.apply(o.toString());
+    return o == null ? missingValue : timestampConverter.apply(o.toString());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
@@ -14,7 +14,8 @@ public class CSVParseSpecTest
     final ParseSpec spec = new CSVParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a", "b"),
@@ -32,7 +33,8 @@ public class CSVParseSpecTest
     final ParseSpec spec = new CSVParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a,", "b"),

--- a/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
@@ -18,7 +18,7 @@ public class DelimitedParseSpecTest
   public void testSerde() throws IOException
   {
     DelimitedParseSpec spec = new DelimitedParseSpec(
-        new TimestampSpec("abc", "iso"),
+        new TimestampSpec("abc", "iso", null),
         new DimensionsSpec(Arrays.asList("abc"), null, null),
         "\u0001",
         "\u0002",
@@ -43,7 +43,8 @@ public class DelimitedParseSpecTest
     final ParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a", "b"),
@@ -62,7 +63,8 @@ public class DelimitedParseSpecTest
     final ParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a,", "b"),
@@ -80,7 +82,8 @@ public class DelimitedParseSpecTest
     final DelimitedParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a", "b"),

--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -23,7 +23,7 @@ public class InputRowParserSerdeTest
   {
     final StringInputRowParser parser = new StringInputRowParser(
         new JSONParseSpec(
-            new TimestampSpec("timestamp", "iso"),
+            new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null)
         )
     );
@@ -47,7 +47,7 @@ public class InputRowParserSerdeTest
   {
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
-            new TimestampSpec("timeposix", "posix"),
+            new TimestampSpec("timeposix", "posix", null),
             new DimensionsSpec(ImmutableList.of("foo", "bar"), ImmutableList.of("baz"), null)
         )
     );
@@ -74,7 +74,7 @@ public class InputRowParserSerdeTest
   {
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
-            new TimestampSpec("timemillis", "millis"),
+            new TimestampSpec("timemillis", "millis", null),
             new DimensionsSpec(ImmutableList.of("foo", "values"), ImmutableList.of("toobig", "value"), null)
         )
     );

--- a/src/test/java/io/druid/data/input/impl/JSONLowercaseParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONLowercaseParseSpecTest.java
@@ -17,7 +17,8 @@ public class JSONLowercaseParseSpecTest
     JSONLowercaseParseSpec spec = new JSONLowercaseParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("A", "B"),

--- a/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
@@ -14,7 +14,8 @@ public class ParseSpecTest
     final ParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a", "b", "a"),
@@ -33,7 +34,8 @@ public class ParseSpecTest
     final ParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a", "B"),
@@ -52,7 +54,8 @@ public class ParseSpecTest
     final ParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec(
             "timestamp",
-            "auto"
+            "auto",
+            null
         ),
         new DimensionsSpec(
             Arrays.asList("a"),

--- a/src/test/java/io/druid/data/input/impl/TimestampSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/TimestampSpecTest.java
@@ -10,10 +10,20 @@ public class TimestampSpecTest
   @Test
   public void testExtractTimestamp() throws Exception
   {
-    TimestampSpec spec = new TimestampSpec("TIMEstamp", "yyyy-MM-dd");
+    TimestampSpec spec = new TimestampSpec("TIMEstamp", "yyyy-MM-dd", null);
     Assert.assertEquals(
         new DateTime("2014-03-01"),
         spec.extractTimestamp(ImmutableMap.<String, Object>of("TIMEstamp", "2014-03-01"))
+    );
+  }
+
+  @Test
+  public void testExtractTimestampWithMissingTimestampColumn() throws Exception
+  {
+    TimestampSpec spec = new TimestampSpec(null, null, new DateTime(0));
+    Assert.assertEquals(
+        new DateTime("1970-01-01"),
+        spec.extractTimestamp(ImmutableMap.<String, Object>of("dim", "foo"))
     );
   }
 }


### PR DESCRIPTION
... column

This is useful for benchmarking data that has no timestamps