### PR TITLE
add interface for FirehoseV2

### DIFF
--- a/src/main/java/io/druid/data/input/Committer.java
+++ b/src/main/java/io/druid/data/input/Committer.java
@@ -1,0 +1,32 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input;
+/**
+ * Committer includes a Runnable and a Jackson-serialized metadata object containing the offset
+ */
+public interface Committer extends Runnable
+{
+    /**
+     * @return A json serialized represenation of commit metadata,
+     * which needs to be serialized and deserialized by Jackson.
+     * Commit metadata can be a complex type, but we recommend keeping it to List/Map/"Primitive JSON" types
+     * */
+    public Object getMetadata();
+}

--- a/src/main/java/io/druid/data/input/FirehoseFactoryV2.java
+++ b/src/main/java/io/druid/data/input/FirehoseFactoryV2.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.metamx.common.parsers.ParseException;
+import io.druid.data.input.impl.InputRowParser;
+
+import java.io.IOException;
+/**
+ * Initialization method that connects up the FirehoseV2.  If this method returns successfully it should be safe to
+ * call start() on the returned FirehoseV2 (which might subsequently block).
+ *
+ * In contrast to V1 version, FirehoseFactoryV2 is able to pass an additional json-serialized object to FirehoseV2,
+ * which contains last commit metadata
+ *
+ * <p/>
+ * If this method returns null, then any attempt to call start(), advance(), currRow(), makeCommitter() and close() on the return
+ * value will throw a surprising NPE.   Throwing IOException on connection failure or runtime exception on
+ * invalid configuration is preferred over returning null.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface FirehoseFactoryV2<T extends InputRowParser>
+{
+  public FirehoseV2 connect(T parser, Object lastCommit) throws IOException, ParseException;
+
+}

--- a/src/main/java/io/druid/data/input/FirehoseV2.java
+++ b/src/main/java/io/druid/data/input/FirehoseV2.java
@@ -1,0 +1,81 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input;
+
+import com.metamx.common.parsers.ParseException;
+
+import java.io.Closeable;
+/**
+ * This is an interface that holds onto the stream of incoming data.  Realtime data ingestion is built around this
+ * abstraction.  In order to add a new type of source for realtime data ingestion, all you need to do is implement
+ * one of these and register it with the Main.
+ *
+ * In contrast to Firehose v1 version, FirehoseV2 will always operate in a "peek, then advance" manner.
+ * And the intended usage patttern is
+ * 1. Call start()
+ * 2. Read currRow()
+ * 3. Call advance()
+ * 4. GOTO 2
+ *
+ * This object acts a lot like an Iterator, but it doesn't extend the Iterator interface because it extends
+ * Closeable and it is very important that the close() method doesn't get forgotten, which is easy to do if this
+ * gets passed around as an Iterator.
+ * <p>
+ * The implementation of this interface only needs to be minimally thread-safe. The methods ##start(), ##advance(),
+ * ##currRow() and ##makeCommitter() are all called from the same thread.  ##makeCommitter(), however, returns a callback
+ * which will be called on another thread, so the operations inside of that callback must be thread-safe.
+ * </p>
+ */
+public interface FirehoseV2 extends Closeable
+{
+    /**
+     * For initial start
+     * */
+    void start() throws Exception;
+
+    /**
+     * Advance the firehose to the next offset
+     * @return true if and when there is another row available, false if the stream has dried up
+     */
+    public boolean advance();
+
+    /**
+     * @return The current row
+     */
+    public InputRow currRow() ;
+
+    /**
+     * Returns a Committer that will "commit" everything read up to the point at which makeCommitter() is called.
+     *
+     * This method is called when the main processing loop starts to persist its current batch of things to process.
+     * The returned committer will be run when the current batch has been successfully persisted
+     * and the metadata committer carries can also be persisted along with segment data. There is usually
+     * some time lag between when this method is called and when the runnable is run.  The Runnable is also run on
+     * a separate thread so its operation should be thread-safe.
+     *
+     * The Runnable is essentially just a lambda/closure that is run() after data supplied by this instance has
+     * been committed on the writer side of this interface protocol.
+     * <p>
+     * A simple implementation of this interface might do nothing when run() is called,
+     * and save proper commit information in metadata
+     * </p>
+     */
+    public Committer makeCommitter();
+}


### PR DESCRIPTION
This PR introduces FirehoseV2 and FirehoseFactoryV2 interface for Kafka simple consumer feature. FirehoseFactoryV2 will pass in a previous persisted metadata, representing the consumer's offset status, and FirehoseV2 is able to start consuming Kafka events at particular offset.
Also FirehoseV2 will always operate in a "peek, then advance" manner. 
The intended usage pattern is:
1. Call start() 
2. Read currRow() 
3. Call advance() 
4. GOTO 2 

Please refer to the google group post for more information https://groups.google.com/forum/#!topic/druid-development/9HB9hCcqvuI