### PR TITLE
Basically, avoid creating new Lists, when there is no mapping for a key

### DIFF
--- a/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -67,6 +67,7 @@ public class MapBasedRow implements Row
     if (dimValue == null) {
       return Collections.emptyList();
     } else if (dimValue instanceof List) {
+      // guava's toString function fails on null objects, so please do not use it
       return Lists.transform((List<Object>) dimValue, TO_STRING_INCLUDING_NULL);
     } else {
       return Collections.singletonList(String.valueOf(dimValue));
@@ -168,7 +169,6 @@ public class MapBasedRow implements Row
     return timestamp.compareTo(o.getTimestamp());
   }
 
-  // guava's toString function checks on non-null objects, so do not use it
   private static final class ToStringFunction implements Function<Object, String>
   {
     @Override

--- a/src/test/java/io/druid/data/input/MapBasedRowTest.java
+++ b/src/test/java/io/druid/data/input/MapBasedRowTest.java
@@ -19,11 +19,16 @@
 
 package io.druid.data.input;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MapBasedRowTest
 {
@@ -51,4 +56,24 @@ public class MapBasedRowTest
     Assert.assertEquals(-9223372036854775807L, row.getLongMetric("k5"));
     Assert.assertEquals(9223372036854775802L, row.getLongMetric("k6"));
   }
+
+  @Test
+  public void testMapWithNull()
+  {
+    Map<String, Object> map = new HashMap<>();
+    map.put("k0", null);
+    map.put("k1", Collections.singletonList(null));
+    map.put("k2", Arrays.asList(null, null, null));
+    MapBasedRow row = new MapBasedRow(new DateTime(), map);
+
+    // A) if value is NULL, then an empty list is returned
+    // (actually, its if (!map.containsKey()), with java8
+    // one should use getOrDefault)
+    Assert.assertEquals(Collections.emptyList(), row.getDimension("k0"));
+
+    // B) if value is a list, then _any_ NULL value is transformed to string "null"
+    Assert.assertEquals(Collections.singletonList("null"), row.getDimension("k1"));
+    Assert.assertEquals(ImmutableList.of("null", "null", "null"), row.getDimension("k2"));
+  }
+
 }


### PR DESCRIPTION
* only one get to the backing map
* use emptyList instead of new ArrayList
* use singletonList instead of Arrays.asList()
* add a test for null handling (a bit confusing)