### PR TITLE
avoid string conversion when parsing timestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.metamx</groupId>
             <artifactId>java-util</artifactId>
-            <version>0.27.2</version>
+            <version>0.27.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/src/main/java/io/druid/data/input/impl/TimestampSpec.java
+++ b/src/main/java/io/druid/data/input/impl/TimestampSpec.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.metamx.common.parsers.ParserUtils;
+import com.metamx.common.parsers.TimestampParser;
 import org.joda.time.DateTime;
 
 import java.util.Map;
@@ -35,7 +36,7 @@ public class TimestampSpec
 
   private final String timestampColumn;
   private final String timestampFormat;
-  private final Function<String, DateTime> timestampConverter;
+  private final Function<Object, DateTime> timestampConverter;
   // this value should never be set for production data
   private final DateTime missingValue;
 
@@ -49,7 +50,7 @@ public class TimestampSpec
   {
     this.timestampColumn = (timestampColumn == null) ? DEFAULT_COLUMN : timestampColumn;
     this.timestampFormat = format == null ? DEFAULT_FORMAT : format;
-    this.timestampConverter = ParserUtils.createTimestampParser(timestampFormat);
+    this.timestampConverter = TimestampParser.createObjectTimestampParser(timestampFormat);
     this.missingValue = missingValue == null
                                        ? DEFAULT_MISSING_VALUE
                                        : missingValue;
@@ -77,7 +78,7 @@ public class TimestampSpec
   {
     final Object o = input.get(timestampColumn);
 
-    return o == null ? missingValue : timestampConverter.apply(o.toString());
+    return o == null ? missingValue : timestampConverter.apply(o);
   }
 
   @Override


### PR DESCRIPTION
avoid string conversion when parsing timestamp
depends on https://github.com/metamx/java-util/pull/27