### PR TITLE
Noop InputRowParser and TimeAndDims ParseSpec

### DIFF
--- a/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -128,4 +128,35 @@ public class DimensionsSpec
         )
     );
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DimensionsSpec that = (DimensionsSpec) o;
+
+    if (!dimensions.equals(that.dimensions)) {
+      return false;
+    }
+    if (!dimensionExclusions.equals(that.dimensionExclusions)) {
+      return false;
+    }
+    return spatialDimensions.equals(that.spatialDimensions);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimensions.hashCode();
+    result = 31 * result + dimensionExclusions.hashCode();
+    result = 31 * result + spatialDimensions.hashCode();
+    return result;
+  }
 }

--- a/src/main/java/io/druid/data/input/impl/InputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/InputRowParser.java
@@ -25,7 +25,8 @@ import io.druid.data.input.InputRow;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = StringInputRowParser.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "string", value = StringInputRowParser.class),
-    @JsonSubTypes.Type(name = "map", value = MapInputRowParser.class)
+    @JsonSubTypes.Type(name = "map", value = MapInputRowParser.class),
+    @JsonSubTypes.Type(name = "noop", value = NoopInputRowParser.class)
 })
 public interface InputRowParser<T>
 {

--- a/src/main/java/io/druid/data/input/impl/NoopInputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/NoopInputRowParser.java
@@ -1,0 +1,79 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.data.input.InputRow;
+
+/**
+ */
+public class NoopInputRowParser implements InputRowParser<InputRow>
+{
+  private final ParseSpec parseSpec;
+
+  @JsonCreator
+  public NoopInputRowParser(
+      @JsonProperty("parseSpec") ParseSpec parseSpec
+  )
+  {
+    this.parseSpec = parseSpec != null ? parseSpec : new TimeAndDimsParseSpec(null, null);
+  }
+
+  @Override
+  public InputRow parse(InputRow input)
+  {
+    return input;
+  }
+
+  @Override
+  public ParseSpec getParseSpec()
+  {
+    return parseSpec;
+  }
+
+  @Override
+  public InputRowParser withParseSpec(ParseSpec parseSpec)
+  {
+    return new NoopInputRowParser(parseSpec);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    NoopInputRowParser that = (NoopInputRowParser) o;
+
+    return parseSpec.equals(that.parseSpec);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return parseSpec.hashCode();
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/ParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/ParseSpec.java
@@ -32,6 +32,7 @@ import java.util.List;
     @JsonSubTypes.Type(name = "csv", value = CSVParseSpec.class),
     @JsonSubTypes.Type(name = "tsv", value = DelimitedParseSpec.class),
     @JsonSubTypes.Type(name = "jsonLowercase", value = JSONLowercaseParseSpec.class),
+    @JsonSubTypes.Type(name = "timeAndDims", value = TimeAndDimsParseSpec.class)
 })
 public abstract class ParseSpec
 {
@@ -74,5 +75,34 @@ public abstract class ParseSpec
   public ParseSpec withDimensionsSpec(DimensionsSpec spec)
   {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ParseSpec parseSpec = (ParseSpec) o;
+
+    if (timestampSpec != null ? !timestampSpec.equals(parseSpec.timestampSpec) : parseSpec.timestampSpec != null) {
+      return false;
+    }
+    return !(dimensionsSpec != null
+             ? !dimensionsSpec.equals(parseSpec.dimensionsSpec)
+             : parseSpec.dimensionsSpec != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = timestampSpec != null ? timestampSpec.hashCode() : 0;
+    result = 31 * result + (dimensionsSpec != null ? dimensionsSpec.hashCode() : 0);
+    return result;
   }
 }

--- a/src/main/java/io/druid/data/input/impl/TimeAndDimsParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/TimeAndDimsParseSpec.java
@@ -1,0 +1,78 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.metamx.common.parsers.Parser;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class TimeAndDimsParseSpec extends ParseSpec
+{
+  @JsonCreator
+  public TimeAndDimsParseSpec(
+      @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
+      @JsonProperty("dimensionsSpec") DimensionsSpec dimensionsSpec
+  )
+  {
+    super(
+        timestampSpec != null ? timestampSpec : new TimestampSpec(null, null, null),
+        dimensionsSpec != null ? dimensionsSpec : new DimensionsSpec(null, null, null)
+    );
+  }
+
+  public Parser<String, Object> makeParser()
+  {
+    return new Parser<String, Object>()
+    {
+      @Override
+      public Map<String, Object> parse(String input)
+      {
+        throw new UnsupportedOperationException("not supported");
+      }
+
+      @Override
+      public void setFieldNames(Iterable<String> fieldNames)
+      {
+        throw new UnsupportedOperationException("not supported");
+      }
+
+      @Override
+      public List<String> getFieldNames()
+      {
+        throw new UnsupportedOperationException("not supported");
+      }
+    };
+  }
+
+  public ParseSpec withTimestampSpec(TimestampSpec spec)
+  {
+    return new TimeAndDimsParseSpec(spec, getDimensionsSpec());
+  }
+
+  public ParseSpec withDimensionsSpec(DimensionsSpec spec)
+  {
+    return new TimeAndDimsParseSpec(getTimestampSpec(), spec);
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/TimestampSpec.java
+++ b/src/main/java/io/druid/data/input/impl/TimestampSpec.java
@@ -79,4 +79,35 @@ public class TimestampSpec
 
     return o == null ? missingValue : timestampConverter.apply(o.toString());
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TimestampSpec that = (TimestampSpec) o;
+
+    if (!timestampColumn.equals(that.timestampColumn)) {
+      return false;
+    }
+    if (!timestampFormat.equals(that.timestampFormat)) {
+      return false;
+    }
+    return !(missingValue != null ? !missingValue.equals(that.missingValue) : that.missingValue != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = timestampColumn.hashCode();
+    result = 31 * result + timestampFormat.hashCode();
+    result = 31 * result + (missingValue != null ? missingValue.hashCode() : 0);
+    return result;
+  }
 }

--- a/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
+++ b/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
@@ -1,0 +1,73 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import junit.framework.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class NoopInputRowParserTest
+{
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testSerdeWithNullParseSpec() throws Exception
+  {
+    String jsonStr = "{ \"type\":\"noop\" }";
+
+    InputRowParser actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, InputRowParser.class)
+        ),
+        InputRowParser.class
+    );
+
+    Assert.assertEquals(new NoopInputRowParser(null), actual);
+  }
+
+  @Test
+  public void testSerdeWithNonNullParseSpec() throws Exception
+  {
+    String jsonStr = "{"
+                     + "\"type\":\"noop\","
+                     + "\"parseSpec\":{ \"format\":\"timeAndDims\", \"dimensionsSpec\": { \"dimensions\": [\"host\"] } }"
+                     + "}";
+
+    InputRowParser actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, InputRowParser.class)
+        ),
+        InputRowParser.class
+    );
+
+    Assert.assertEquals(
+        new NoopInputRowParser(
+            new TimeAndDimsParseSpec(
+                null,
+                new DimensionsSpec(ImmutableList.of("host"), null, null)
+            )
+        ),
+        actual
+    );
+  }
+}

--- a/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
@@ -1,0 +1,72 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import junit.framework.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class TimeAndDimsParseSpecTest
+{
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testSerdeWithNulls() throws Exception
+  {
+    String jsonStr = "{ \"format\":\"timeAndDims\" }";
+
+    ParseSpec actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, ParseSpec.class)
+        ),
+        ParseSpec.class
+    );
+
+    Assert.assertEquals(new TimeAndDimsParseSpec(null, null), actual);
+  }
+
+  @Test
+  public void testSerdeWithNonNulls() throws Exception
+  {
+    String jsonStr = "{"
+                     + "\"format\":\"timeAndDims\","
+                     + "\"timestampSpec\": { \"column\": \"tcol\" },"
+                     + "\"dimensionsSpec\": { \"dimensions\": [\"host\"] }"
+                     + "}";
+
+    ParseSpec actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, ParseSpec.class)
+        ),
+        ParseSpec.class
+    );
+
+    Assert.assertEquals(
+        new TimeAndDimsParseSpec(
+            new TimestampSpec("tcol", null, null),
+            new DimensionsSpec(ImmutableList.of("host"), null, null)
+        ),
+        actual
+    );
+  }
+}


### PR DESCRIPTION
In many ingestion scenarios you don't have raw data in csv, tsv etc format but something pre-parsed. In those situations mostly you just want a noop input row parser and optionally want to provide timestamp spec and/or dimensions spec.
One such example is when you are doing batch reindexing. It is weird to specify things like string parser with json parse spec and noop would be more sensible.