### PR TITLE
Allow flattening of JSON during ingestion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.metamx</groupId>
             <artifactId>java-util</artifactId>
-            <version>0.27.3</version>
+            <version>0.27.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
+++ b/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
@@ -1,0 +1,76 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JSONPathFieldSpec
+{
+  private final JSONPathFieldType type;
+  private final String name;
+  private final String expr;
+
+  @JsonCreator
+  public JSONPathFieldSpec(
+      @JsonProperty("type") JSONPathFieldType type,
+      @JsonProperty("name") String name,
+      @JsonProperty("expr") String expr
+  )
+  {
+    this.type = type;
+    this.name = name;
+    this.expr = expr;
+  }
+
+  @JsonProperty
+  public JSONPathFieldType getType()
+  {
+    return type;
+  }
+
+  @JsonProperty
+  public String getName()
+  {
+    return name;
+  }
+
+  @JsonProperty
+  public String getExpr()
+  {
+    return expr;
+  }
+
+  @JsonCreator
+  public static JSONPathFieldSpec fromString(String name)
+  {
+    return JSONPathFieldSpec.createRootField(name);
+  }
+
+  public static JSONPathFieldSpec createNestedField(String name, String expr)
+  {
+    return new JSONPathFieldSpec(JSONPathFieldType.PATH, name, expr);
+  }
+
+  public static JSONPathFieldSpec createRootField(String name)
+  {
+    return new JSONPathFieldSpec(JSONPathFieldType.ROOT, name, name);
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/JSONPathFieldType.java
+++ b/src/main/java/io/druid/data/input/impl/JSONPathFieldType.java
@@ -1,0 +1,42 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum JSONPathFieldType
+{
+  ROOT,
+  PATH;
+
+  @JsonValue
+  @Override
+  public String toString()
+  {
+    return this.name().toLowerCase();
+  }
+
+  @JsonCreator
+  public static JSONPathFieldType fromString(String name)
+  {
+    return valueOf(name.toUpperCase());
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/JSONPathSpec.java
+++ b/src/main/java/io/druid/data/input/impl/JSONPathSpec.java
@@ -1,0 +1,54 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class JSONPathSpec
+{
+  private final boolean useFieldDiscovery;
+  private final List<JSONPathFieldSpec> fields;
+
+  @JsonCreator
+  public JSONPathSpec(
+      @JsonProperty("useFieldDiscovery") Boolean useFieldDiscovery,
+      @JsonProperty("fields") List<JSONPathFieldSpec> fields
+  )
+  {
+    this.useFieldDiscovery = useFieldDiscovery == null ? true : useFieldDiscovery;
+    this.fields = fields == null ? ImmutableList.<JSONPathFieldSpec>of() : fields;
+  }
+
+  @JsonProperty
+  public boolean isUseFieldDiscovery()
+  {
+    return useFieldDiscovery;
+  }
+
+  @JsonProperty
+  public List<JSONPathFieldSpec> getFields()
+  {
+    return fields;
+  }
+}

--- a/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
@@ -1,0 +1,81 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import io.druid.TestObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class JSONPathSpecTest
+{
+  private final ObjectMapper jsonMapper = new TestObjectMapper();
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    List<JSONPathFieldSpec> fields = new ArrayList<>();
+    fields.add(JSONPathFieldSpec.createNestedField("foobar1", "$.foo.bar1"));
+    fields.add(JSONPathFieldSpec.createNestedField("baz0", "$.baz[0]"));
+    fields.add(JSONPathFieldSpec.createNestedField("hey0barx", "$.hey[0].barx"));
+    fields.add(JSONPathFieldSpec.createRootField("timestamp"));
+    fields.add(JSONPathFieldSpec.createRootField("foo.bar1"));
+
+    JSONPathSpec flattenSpec = new JSONPathSpec(true, fields);
+
+    final JSONPathSpec serde = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(flattenSpec),
+        JSONPathSpec.class
+    );
+    Assert.assertTrue(serde.isUseFieldDiscovery());
+    List<JSONPathFieldSpec> serdeFields = serde.getFields();
+    JSONPathFieldSpec foobar1 = serdeFields.get(0);
+    JSONPathFieldSpec baz0 = serdeFields.get(1);
+    JSONPathFieldSpec hey0barx = serdeFields.get(2);
+    JSONPathFieldSpec timestamp = serdeFields.get(3);
+    JSONPathFieldSpec foodotbar1 = serdeFields.get(4);
+
+    Assert.assertEquals(JSONPathFieldType.PATH, foobar1.getType());
+    Assert.assertEquals("foobar1", foobar1.getName());
+    Assert.assertEquals("$.foo.bar1", foobar1.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.PATH, baz0.getType());
+    Assert.assertEquals("baz0", baz0.getName());
+    Assert.assertEquals("$.baz[0]", baz0.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.PATH, hey0barx.getType());
+    Assert.assertEquals("hey0barx", hey0barx.getName());
+    Assert.assertEquals("$.hey[0].barx", hey0barx.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.ROOT, timestamp.getType());
+    Assert.assertEquals("timestamp", timestamp.getName());
+    Assert.assertEquals("timestamp", timestamp.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.ROOT, foodotbar1.getType());
+    Assert.assertEquals("foo.bar1", foodotbar1.getName());
+    Assert.assertEquals("foo.bar1", foodotbar1.getExpr());
+  }
+}


### PR DESCRIPTION
Part of a set of 3 related pull requests, addressing Druid issue:
 https://github.com/druid-io/druid/issues/1839

https://github.com/metamx/java-util/pull/34   -- new JSON parser 
https://github.com/druid-io/druid-api/pull/65  -- ingestion spec modifications
https://github.com/druid-io/druid/pull/1921  -- docs and benchmark

Adds a new flattenSpec to the JSONParseSpec that defines field names and accessors for flattening with a new parser that uses the JsonPath library.