### PR TITLE
Allow json parser to set Feature

### DIFF
--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -47,6 +47,7 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            null,
             null
         )
     );
@@ -89,6 +90,7 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timeposix", "posix", null),
             new DimensionsSpec(ImmutableList.of("foo", "bar"), ImmutableList.of("baz"), null),
+            null,
             null
         )
     );
@@ -117,6 +119,7 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timemillis", "millis", null),
             new DimensionsSpec(ImmutableList.of("foo", "values"), ImmutableList.of("toobig", "value"), null),
+            null,
             null
         )
     );
@@ -153,6 +156,7 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            null,
             null
         ),
         charset.name()
@@ -191,7 +195,8 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(null, null, null),
-            flattenSpec
+            flattenSpec,
+            null
         )
     );
 

--- a/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -1,0 +1,59 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import io.druid.TestObjectMapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+
+public class JSONParseSpecTest {
+  private final ObjectMapper jsonMapper = new TestObjectMapper();
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    HashMap<String, Boolean> feature = new HashMap<String, Boolean>();
+    feature.put("ALLOW_UNQUOTED_CONTROL_CHARS", true);
+    JSONParseSpec spec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(ImmutableList.of("bar", "foo"), null, null),
+        null,
+        feature
+    );
+
+    final JSONParseSpec serde = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(spec),
+        JSONParseSpec.class
+    );
+    Assert.assertEquals("timestamp", serde.getTimestampSpec().getTimestampColumn());
+    Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
+
+    Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(feature, serde.getFeatureSpec());
+  }
+}


### PR DESCRIPTION
        "parseSpec" : {
          "format" : "json",
          "timestampSpec" : {
            "column" : "timestamp",
            "format" : "auto"
          },
          "dimensionsSpec" : {
            "dimensions": [],
            "dimensionExclusions" : [],
            "spatialDimensions" : []
          },
          "featureSpec" : {
            "ALLOW_UNQUOTED_CONTROL_CHARS":"true", 
            "ALLOW_SINGLE_QUOTES":"true",          
            "ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER":"true"
          }
        }