### PR TITLE
Remove lexicographic sorting of dimensions in DimensionsSpec

### DIFF
--- a/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -49,9 +49,6 @@ public class DimensionsSpec
                       ? Lists.<String>newArrayList()
                       : Lists.newArrayList(dimensions);
 
-    // Small work around for https://github.com/metamx/druid/issues/658
-    Collections.sort(this.dimensions, Ordering.natural().nullsFirst());
-
     this.dimensionExclusions = (dimensionExclusions == null)
                                ? Sets.<String>newHashSet()
                                : Sets.newHashSet(dimensionExclusions);

--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -56,7 +56,7 @@ public class InputRowParserSerdeTest
             "{\"foo\":\"x\",\"bar\":\"y\",\"qux\":\"z\",\"timestamp\":\"2000\"}".getBytes(Charsets.UTF_8)
         )
     );
-    Assert.assertEquals(ImmutableList.of("bar", "foo"), parsed.getDimensions());
+    Assert.assertEquals(ImmutableList.of("foo", "bar"), parsed.getDimensions());
     Assert.assertEquals(ImmutableList.of("x"), parsed.getDimension("foo"));
     Assert.assertEquals(ImmutableList.of("y"), parsed.getDimension("bar"));
     Assert.assertEquals(new DateTime("2000").getMillis(), parsed.getTimestampFromEpoch());
@@ -72,7 +72,7 @@ public class InputRowParserSerdeTest
 
     for (Charset testCharset : testCharsets) {
       InputRow parsed = testCharsetParseHelper(testCharset);
-      Assert.assertEquals(ImmutableList.of("bar", "foo"), parsed.getDimensions());
+      Assert.assertEquals(ImmutableList.of("foo", "bar"), parsed.getDimensions());
       Assert.assertEquals(ImmutableList.of("x"), parsed.getDimension("foo"));
       Assert.assertEquals(ImmutableList.of("y"), parsed.getDimension("bar"));
       Assert.assertEquals(new DateTime("3000").getMillis(), parsed.getTimestampFromEpoch());
@@ -100,7 +100,7 @@ public class InputRowParserSerdeTest
             "timeposix", "1"
         )
     );
-    Assert.assertEquals(ImmutableList.of("bar", "foo"), parsed.getDimensions());
+    Assert.assertEquals(ImmutableList.of("foo", "bar"), parsed.getDimensions());
     Assert.assertEquals(ImmutableList.of("x"), parsed.getDimension("foo"));
     Assert.assertEquals(ImmutableList.of("y"), parsed.getDimension("bar"));
     Assert.assertEquals(1000, parsed.getTimestampFromEpoch());


### PR DESCRIPTION
Relates to https://github.com/druid-io/druid/pull/1974

Removes the automatic lexicographic sorting of the dimensions specified in the DimensionsSpec