### PR TITLE
Support custom parser implementation

### DIFF
--- a/src/main/java/io/druid/data/input/impl/CustomParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/CustomParseSpec.java
@@ -1,3 +1,22 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
 package io.druid.data.input.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -39,7 +58,10 @@ public class CustomParseSpec extends ParseSpec
                          .getConstructor(TimestampSpec.class, DimensionsSpec.class, Map.class);
     }
     catch (Exception e) {
-      throw new IllegalArgumentException(e);
+      throw new IllegalArgumentException(
+          "Failed to find proper constructor of parser `" + parserClass + "` by exception " + e,
+          e
+      );
     }
   }
 

--- a/src/main/java/io/druid/data/input/impl/CustomParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/CustomParseSpec.java
@@ -1,0 +1,81 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.parsers.Parser;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+/**
+ */
+public class CustomParseSpec extends ParseSpec
+{
+
+  private final String parserClass;
+  private final Map<String, Object> properties;
+
+  private final Constructor constructor;
+
+  @JsonCreator
+  public CustomParseSpec(
+      @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
+      @JsonProperty("dimensionsSpec") DimensionsSpec dimensionsSpec,
+      @JsonProperty("parserClass") String parserClass,
+      @JsonProperty("properties") Map<String, Object> properties
+  )
+  {
+    super(timestampSpec, dimensionsSpec);
+
+    this.parserClass = parserClass;
+    this.properties = properties == null ? ImmutableMap.<String, Object>of() : properties;
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    if (loader == null) {
+      loader = ParseSpec.class.getClassLoader();
+    }
+    try {
+      constructor = Class.forName(parserClass, true, loader)
+                         .getConstructor(TimestampSpec.class, DimensionsSpec.class, Map.class);
+    }
+    catch (Exception e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @JsonProperty("parserClass")
+  public String getParserClass()
+  {
+    return parserClass;
+  }
+
+  @JsonProperty("properties")
+  public Map<String, Object> getProperties()
+  {
+    return properties;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Parser<String, Object> makeParser()
+  {
+    try {
+      return (Parser<String, Object>) constructor.newInstance(getTimestampSpec(), getDimensionsSpec(), getProperties());
+    }
+    catch (Exception e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @Override
+  public ParseSpec withTimestampSpec(TimestampSpec spec)
+  {
+    return new CustomParseSpec(spec, getDimensionsSpec(), getParserClass(), getProperties());
+  }
+
+  @Override
+  public ParseSpec withDimensionsSpec(DimensionsSpec spec)
+  {
+    return new CustomParseSpec(getTimestampSpec(), spec, getParserClass(), getProperties());
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
@@ -19,14 +19,14 @@ package io.druid.data.input.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.metamx.common.parsers.DelimitedParser;
-import com.metamx.common.parsers.ParseException;
 import com.metamx.common.parsers.Parser;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -56,6 +56,23 @@ public class DelimitedParseSpec extends ParseSpec
     }
 
     verify(dimensionsSpec.getDimensions());
+  }
+
+  @VisibleForTesting
+  @SuppressWarnings("unchecked")
+  public DelimitedParseSpec(
+      TimestampSpec timestampSpec,
+      DimensionsSpec dimensionsSpec,
+      Map<String, Object> properties
+  )
+  {
+    this(
+        timestampSpec,
+        dimensionsSpec,
+        (String) properties.get("delimiter"),
+        (String) properties.get("listDelimiter"),
+        (List<String>) properties.get("columns")
+    );
   }
 
   @JsonProperty("delimiter")

--- a/src/main/java/io/druid/data/input/impl/ParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/ParseSpec.java
@@ -34,7 +34,8 @@ import java.util.List;
     @JsonSubTypes.Type(name = "jsonLowercase", value = JSONLowercaseParseSpec.class),
     @JsonSubTypes.Type(name = "timeAndDims", value = TimeAndDimsParseSpec.class),
     @JsonSubTypes.Type(name = "regex", value = RegexParseSpec.class),
-    @JsonSubTypes.Type(name = "javascript", value = JavaScriptParseSpec.class)
+    @JsonSubTypes.Type(name = "javascript", value = JavaScriptParseSpec.class),
+    @JsonSubTypes.Type(name = "custom", value = CustomParseSpec.class)
 
 })
 public abstract class ParseSpec

--- a/src/test/java/io/druid/data/input/impl/CustomParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/CustomParseSpecTest.java
@@ -1,0 +1,62 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.druid.TestObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+public class CustomParseSpecTest
+{
+  private final ObjectMapper jsonMapper = new TestObjectMapper();
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    Map<String, Object> properties = ImmutableMap.of(
+        "delimiter", "\u0001",
+        "listDelimiter", "\u0002",
+        "columns", Arrays.asList("abc")
+    );
+    CustomParseSpec spec = new CustomParseSpec(
+        new TimestampSpec("abc", "iso", null),
+        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        DelimitedParseSpec.class.getName(),
+        properties
+    );
+    final CustomParseSpec serde = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(spec),
+        CustomParseSpec.class
+    );
+    Assert.assertEquals("abc", serde.getTimestampSpec().getTimestampColumn());
+    Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
+
+    Assert.assertEquals(Arrays.asList("abc"), serde.getProperties().get("columns"));
+    Assert.assertEquals("\u0001", serde.getProperties().get("delimiter"));
+    Assert.assertEquals("\u0002", serde.getProperties().get("listDelimiter"));
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+  }
+}


### PR DESCRIPTION
With input stream with some arbitrary format, we cannot use it directly before the format is supported in druid. java script parse spec is a good alternative but I don't know java script.
