### PR TITLE
efficiently use hdfs namespace quota

### DIFF
--- a/src/main/java/io/druid/segment/loading/DataSegmentPusherUtil.java
+++ b/src/main/java/io/druid/segment/loading/DataSegmentPusherUtil.java
@@ -29,10 +29,7 @@ public class DataSegmentPusherUtil
 {
   private static final Joiner JOINER = Joiner.on("/").skipNulls();
 
-  // Note: storage directory structure format = .../dataSource/interval/version/partitionNumber/
-  // If above format is ever changed, make sure to change it appropriately in other places
-  // e.g. HDFSDataSegmentKiller uses this information to clean the version, interval and dataSource directories
-  // on segment deletion if segment being deleted was the only segment
+
   public static String getStorageDir(DataSegment segment)
   {
     return JOINER.join(
@@ -47,6 +44,10 @@ public class DataSegmentPusherUtil
     );
   }
 
+  // Note: storage directory structure format
+  // If format is ever changed, make sure to change it appropriately in other places
+  // e.g. HDFSDataSegmentKiller uses this information to clean directories properly.
+  // on segment deletion if segment being deleted was the only segment
   /**
    * Due to https://issues.apache.org/jira/browse/HDFS-13 ":" are not allowed in
    * path names. So we format paths differently for HDFS.
@@ -56,12 +57,12 @@ public class DataSegmentPusherUtil
     return JOINER.join(
         segment.getDataSource(),
         String.format(
-            "%s_%s",
+            "%s_%s_%s_%s",
             segment.getInterval().getStart().toString(ISODateTimeFormat.basicDateTime()),
-            segment.getInterval().getEnd().toString(ISODateTimeFormat.basicDateTime())
-        ),
-        segment.getVersion().replaceAll(":", "_"),
-        segment.getShardSpec().getPartitionNum()
+            segment.getInterval().getEnd().toString(ISODateTimeFormat.basicDateTime()),
+            segment.getVersion().replaceAll(":", "_"),
+            segment.getShardSpec().getPartitionNum()
+        )
     );
   }
 }

--- a/src/test/java/io/druid/segment/loading/DataSegmentPusherUtilTest.java
+++ b/src/test/java/io/druid/segment/loading/DataSegmentPusherUtilTest.java
@@ -49,7 +49,7 @@ public class DataSegmentPusherUtilTest
         );
 
         String storageDir = DataSegmentPusherUtil.getHdfsStorageDir(segment);
-        Assert.assertEquals("something/20111001T000000.000Z_20111002T000000.000Z/brand_new_version/0", storageDir);
+        Assert.assertEquals("something/20111001T000000.000Z_20111002T000000.000Z_brand_new_version_0", storageDir);
 
     }
 }


### PR DESCRIPTION
from `dataSource/start_end/version/partitionNum` to `dataSource/start_end_version_partitionNum`

hdfs namenode file name quota is scarce resource and we need to be efficient in how and how much we utilized it. in the best case this reduces 2 per segment.

also see https://github.com/druid-io/druid/pull/2412