### PR TITLE
Add DimensionSchema class for specifying dimension properties

### DIFF
--- a/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
@@ -52,7 +52,7 @@ public class CSVParseSpec extends ParseSpec
 
     this.columns = columns;
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty

--- a/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
@@ -55,7 +55,7 @@ public class DelimitedParseSpec extends ParseSpec
       Preconditions.checkArgument(!column.contains(","), "Column[%s] has a comma, it cannot", column);
     }
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty("delimiter")

--- a/src/main/java/io/druid/data/input/impl/DimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionSchema.java
@@ -1,0 +1,84 @@
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class DimensionSchema
+{
+  // This should really use ValueType from main Druid.
+  // TODO: get rid of this when druid-api is merged back into the main repo
+  public enum ValueType
+  {
+    FLOAT,
+    LONG,
+    STRING;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return this.name().toUpperCase();
+    }
+
+    @JsonCreator
+    public static ValueType fromString(String name)
+    {
+      return valueOf(name.toUpperCase());
+    }
+  }
+
+  private final String name;
+  private final ValueType type;
+  private final boolean isSpatial;
+  private final List<String> subdimensions;
+
+  @JsonCreator
+  public DimensionSchema(
+      @JsonProperty("name") String name,
+      @JsonProperty("type") ValueType type,
+      @JsonProperty("isSpatial") Boolean isSpatial,
+      @JsonProperty("subdimensions") List<String> subdimensions
+  )
+  {
+    Preconditions.checkArgument(name != null, "Dimension name cannot be null.");
+    this.name = name;
+    this.type = type == null ? ValueType.STRING : type;
+    this.isSpatial = isSpatial == null ? false : isSpatial;
+    this.subdimensions = subdimensions;
+  }
+
+  public DimensionSchema(
+      String name
+  )
+  {
+    this(name, null, null, null);
+  }
+
+  @JsonProperty
+  public String getName()
+  {
+    return name;
+  }
+
+  @JsonProperty
+  public ValueType getType()
+  {
+    return type;
+  }
+
+  @JsonProperty("isSpatial")
+  public boolean isSpatial()
+  {
+    return isSpatial;
+  }
+
+  @JsonProperty
+  public List<String> getSubdimensions()
+  {
+    return subdimensions;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/DimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionSchema.java
@@ -1,3 +1,22 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
 package io.druid.data.input.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -80,5 +99,40 @@ public class DimensionSchema
   public List<String> getSubdimensions()
   {
     return subdimensions;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DimensionSchema that = (DimensionSchema) o;
+
+    if (isSpatial != that.isSpatial) {
+      return false;
+    }
+    if (!name.equals(that.name)) {
+      return false;
+    }
+    if (type != that.type) {
+      return false;
+    }
+    return subdimensions != null ? subdimensions.equals(that.subdimensions) : that.subdimensions == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = name.hashCode();
+    result = 31 * result + type.hashCode();
+    result = 31 * result + (isSpatial ? 1 : 0);
+    result = 31 * result + (subdimensions != null ? subdimensions.hashCode() : 0);
+    return result;
   }
 }

--- a/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.metamx.common.IAE;
 import com.metamx.common.parsers.ParserUtils;
 
 import javax.annotation.Nullable;
@@ -45,7 +46,7 @@ public class DimensionsSpec
   private final Map<String, DimensionSchema> dimensionSchemaMap;
 
   @Deprecated
-  private final List<SpatialDimensionSchema> spatialDimensions;
+  private List<SpatialDimensionSchema> spatialDimensions;
 
   public static List<DimensionSchema> getDefaultSchemas(List<String> dimNames)
   {
@@ -93,16 +94,22 @@ public class DimensionsSpec
 
     verify();
 
-    for(SpatialDimensionSchema spatialSchema : this.spatialDimensions) {
-      this.dimensions.add(DimensionsSpec.convertSpatialSchema(spatialSchema));
-    }
-    this.spatialDimensions.clear();
-
     // Map for easy dimension name-based schema lookup
     this.dimensionSchemaMap = new HashMap<>();
     for (DimensionSchema schema : this.dimensions) {
       dimensionSchemaMap.put(schema.getName(), schema);
     }
+
+    for(SpatialDimensionSchema spatialSchema : this.spatialDimensions) {
+      DimensionSchema newSchema = DimensionsSpec.convertSpatialSchema(spatialSchema);
+      this.dimensions.add(newSchema);
+      dimensionSchemaMap.put(newSchema.getName(), newSchema);
+    }
+
+    this.spatialDimensions = null;
+    //this.spatialDimensions.clear();
+
+
   }
 
 

--- a/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
@@ -46,7 +46,7 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
   public InputRow parse(Map<String, Object> theMap)
   {
     final List<String> dimensions = parseSpec.getDimensionsSpec().hasCustomDimensions()
-                                    ? parseSpec.getDimensionsSpec().getDimensions()
+                                    ? parseSpec.getDimensionsSpec().getDimensionNames()
                                     : Lists.newArrayList(
                                         Sets.difference(
                                             theMap.keySet(),

--- a/src/main/java/io/druid/data/input/impl/RegexParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/RegexParseSpec.java
@@ -51,7 +51,7 @@ public class RegexParseSpec extends ParseSpec
     this.columns = columns;
     this.pattern = pattern;
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty

--- a/src/main/java/io/druid/data/input/impl/SpatialDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/SpatialDimensionSchema.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 /**
  */
+@Deprecated
 public class SpatialDimensionSchema
 {
   private final String dimName;
@@ -49,5 +50,32 @@ public class SpatialDimensionSchema
   public List<String> getDims()
   {
     return dims;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SpatialDimensionSchema that = (SpatialDimensionSchema) o;
+
+    if (!dimName.equals(that.dimName)) {
+      return false;
+    }
+    return dims != null ? dims.equals(that.dims) : that.dims == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimName.hashCode();
+    result = 31 * result + (dims != null ? dims.hashCode() : 0);
+    return result;
   }
 }

--- a/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
@@ -37,7 +37,7 @@ public class CSVParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -56,7 +56,7 @@ public class CSVParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a,", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a,", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
@@ -38,7 +38,7 @@ public class DelimitedParseSpecTest
   {
     DelimitedParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "\u0001",
         "\u0002",
         Arrays.asList("abc")
@@ -53,7 +53,7 @@ public class DelimitedParseSpecTest
     Assert.assertEquals(Arrays.asList("abc"), serde.getColumns());
     Assert.assertEquals("\u0001", serde.getDelimiter());
     Assert.assertEquals("\u0002", serde.getListDelimiter());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -66,7 +66,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -86,7 +86,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a,", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a,", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -105,7 +105,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
@@ -19,34 +19,33 @@
 
 package io.druid.data.input.impl;
 
-import com.google.common.collect.Lists;
-import com.metamx.common.parsers.JSONToLowerParser;
-import com.metamx.common.parsers.Parser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import junit.framework.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Map;
-
-public class JSONLowercaseParseSpecTest
+/**
+ */
+public class DimensionsSpecSerdeTest
 {
+  private final ObjectMapper mapper = new ObjectMapper();
+
   @Test
-  public void testLowercasing() throws Exception
+  public void testDimensionsSpecSerde() throws Exception
   {
-    JSONLowercaseParseSpec spec = new JSONLowercaseParseSpec(
-        new TimestampSpec(
-            "timestamp",
-            "auto",
-            null
+    String jsonStr = "{"
+                     + "\"dimensions\":[\"AAA\", \"BIX\", {\"name\":\"CCCP\", \"type\":\"FLOAT\"}]"
+                     + "}";
+
+    DimensionsSpec actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, DimensionsSpec.class)
         ),
-        new DimensionsSpec(
-            DimensionsSpec.getDefaultSchemas(Arrays.asList("A", "B")),
-            Lists.<String>newArrayList(),
-            Lists.<SpatialDimensionSchema>newArrayList()
-        )
+        DimensionsSpec.class
     );
-    Parser parser = spec.makeParser();
-    Map<String, Object> event = parser.parse("{\"timestamp\":\"2015-01-01\",\"A\":\"foo\"}");
-    Assert.assertEquals("foo", event.get("a"));
+
+
+    System.out.println("HELLO WORLD");
+
   }
 }

--- a/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
@@ -24,6 +24,9 @@ import com.google.common.collect.ImmutableList;
 import junit.framework.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  */
 public class DimensionsSpecSerdeTest
@@ -33,8 +36,11 @@ public class DimensionsSpecSerdeTest
   @Test
   public void testDimensionsSpecSerde() throws Exception
   {
-    String jsonStr = "{"
-                     + "\"dimensions\":[\"AAA\", \"BIX\", {\"name\":\"CCCP\", \"type\":\"FLOAT\"}]"
+    String jsonStr = "{\"dimensions\":[\"AAA\", \"BIS\","
+                     + "{\"name\":\"CCCP\", \"type\":\"FLOAT\"}, {\"name\":\"DDT\", \"isSpatial\":true},"
+                     + "{\"name\":\"EEK\", \"subdimensions\":[\"X\",\"Y\",\"Z\"]}],"
+                     + "\"dimensionExclusions\": [\"FOO\", \"HAR\"],"
+                     + "\"spatialDimensions\": [{\"dimName\":\"IMPR\", \"dims\":[\"S\",\"P\",\"Q\",\"R\"]}]"
                      + "}";
 
     DimensionsSpec actual = mapper.readValue(
@@ -44,8 +50,25 @@ public class DimensionsSpecSerdeTest
         DimensionsSpec.class
     );
 
+    DimensionsSpec expected = new DimensionsSpec(
+        Arrays.asList(
+            new DimensionSchema("AAA"),
+            new DimensionSchema("BIS"),
+            new DimensionSchema("CCCP", DimensionSchema.ValueType.FLOAT, false, null),
+            new DimensionSchema("DDT", null, true, null),
+            new DimensionSchema("EEK", DimensionSchema.ValueType.STRING, false, Arrays.asList("X","Y","Z")),
+            new DimensionSchema("IMPR", null, true, Arrays.asList("S","P","Q","R"))
+        ),
+        Arrays.asList("FOO", "HAR"),
+        null
+    );
 
-    System.out.println("HELLO WORLD");
+    List<SpatialDimensionSchema> expectedSpatials = Arrays.asList(
+        new SpatialDimensionSchema("DDT", null),
+        new SpatialDimensionSchema("IMPR",Arrays.asList("S","P","Q","R"))
+    );
 
+    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(expectedSpatials, actual.getSpatialDimensions());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
+++ b/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
@@ -63,7 +63,7 @@ public class FileIteratingFirehoseTest
       final StringInputRowParser parser = new StringInputRowParser(
           new CSVParseSpec(
               new TimestampSpec("ts", "auto", null),
-              new DimensionsSpec(ImmutableList.of("x"), null, null),
+              new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("x")), null, null),
               ",",
               ImmutableList.of("ts", "x")
           )

--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -46,7 +46,7 @@ public class InputRowParserSerdeTest
     final StringInputRowParser parser = new StringInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
             null
         )
@@ -89,7 +89,7 @@ public class InputRowParserSerdeTest
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timeposix", "posix", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), ImmutableList.of("baz"), null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), ImmutableList.of("baz"), null),
             null,
             null
         )
@@ -118,7 +118,7 @@ public class InputRowParserSerdeTest
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timemillis", "millis", null),
-            new DimensionsSpec(ImmutableList.of("foo", "values"), ImmutableList.of("toobig", "value"), null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "values")), ImmutableList.of("toobig", "value"), null),
             null,
             null
         )
@@ -155,7 +155,7 @@ public class InputRowParserSerdeTest
     final StringInputRowParser parser = new StringInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
             null
         ),

--- a/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -41,7 +41,7 @@ public class JSONParseSpecTest {
     feature.put("ALLOW_UNQUOTED_CONTROL_CHARS", true);
     JSONParseSpec spec = new JSONParseSpec(
         new TimestampSpec("timestamp", "iso", null),
-        new DimensionsSpec(ImmutableList.of("bar", "foo"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
         null,
         feature
     );

--- a/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -53,7 +53,7 @@ public class JSONParseSpecTest {
     Assert.assertEquals("timestamp", serde.getTimestampSpec().getTimestampColumn());
     Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
 
-    Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensionNames());
     Assert.assertEquals(feature, serde.getFeatureSpec());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
@@ -38,7 +38,7 @@ public class JavaScriptParseSpecTest
   {
     JavaScriptParseSpec spec = new JavaScriptParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "abc"
     );
     final JavaScriptParseSpec serde = jsonMapper.readValue(
@@ -49,6 +49,6 @@ public class JavaScriptParseSpecTest
     Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
 
     Assert.assertEquals("abc", serde.getFunction());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
+++ b/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
@@ -64,7 +64,7 @@ public class NoopInputRowParserTest
         new NoopInputRowParser(
             new TimeAndDimsParseSpec(
                 null,
-                new DimensionsSpec(ImmutableList.of("host"), null, null)
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null)
             )
         ),
         actual

--- a/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
@@ -37,7 +37,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b", "a"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b", "a")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -57,7 +57,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "B"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "B")),
             Lists.newArrayList("B"),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -77,7 +77,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a")),
             Lists.newArrayList("B", "B"),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
@@ -38,7 +38,7 @@ public class RegexParseSpecTest
   {
     RegexParseSpec spec = new RegexParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "\u0001",
         Arrays.asList("abc"),
         "abc"

--- a/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
@@ -52,6 +52,6 @@ public class RegexParseSpecTest
 
     Assert.assertEquals("abc", serde.getPattern());
     Assert.assertEquals("\u0001", serde.getListDelimiter());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
@@ -64,7 +64,7 @@ public class TimeAndDimsParseSpecTest
     Assert.assertEquals(
         new TimeAndDimsParseSpec(
             new TimestampSpec("tcol", null, null),
-            new DimensionsSpec(ImmutableList.of("host"), null, null)
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null)
         ),
         actual
     );


### PR DESCRIPTION
This patch allows a user to specify the types of dimension columns (Long, Float, or String).

Needed to support the following PR:
- https://github.com/druid-io/druid/pull/2442