### PR TITLE
Add DimensionSchema for specifying dimension types and properties

### DIFF
--- a/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
@@ -52,7 +52,7 @@ public class CSVParseSpec extends ParseSpec
 
     this.columns = columns;
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty

--- a/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
@@ -55,7 +55,7 @@ public class DelimitedParseSpec extends ParseSpec
       Preconditions.checkArgument(!column.contains(","), "Column[%s] has a comma, it cannot", column);
     }
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty("delimiter")

--- a/src/main/java/io/druid/data/input/impl/DimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionSchema.java
@@ -1,0 +1,114 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+/**
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = StringDimensionSchema.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = DimensionSchema.STRING_TYPE_NAME, value = StringDimensionSchema.class),
+    @JsonSubTypes.Type(name = DimensionSchema.LONG_TYPE_NAME, value = LongDimensionSchema.class),
+    @JsonSubTypes.Type(name = DimensionSchema.FLOAT_TYPE_NAME, value = FloatDimensionSchema.class),
+    @JsonSubTypes.Type(name = DimensionSchema.SPATIAL_TYPE_NAME, value = NewSpatialDimensionSchema.class),
+})
+public abstract class DimensionSchema
+{
+  public static final String STRING_TYPE_NAME = "string";
+  public static final String LONG_TYPE_NAME = "long";
+  public static final String FLOAT_TYPE_NAME = "float";
+  public static final String SPATIAL_TYPE_NAME = "spatial";
+
+
+  // main druid and druid-api should really use the same ValueType enum.
+  // merge them when druid-api is merged back into the main repo
+  public enum ValueType
+  {
+    FLOAT,
+    LONG,
+    STRING,
+    COMPLEX;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return this.name().toUpperCase();
+    }
+
+    @JsonCreator
+    public static ValueType fromString(String name)
+    {
+      return valueOf(name.toUpperCase());
+    }
+  }
+
+  private final String name;
+
+  protected DimensionSchema(String name)
+  {
+    this.name = Preconditions.checkNotNull(name, "Dimension name cannot be null.");
+  }
+
+  @JsonProperty
+  public String getName()
+  {
+    return name;
+  };
+
+  @JsonIgnore
+  public abstract String getTypeName();
+
+  @JsonIgnore
+  public abstract ValueType getValueType();
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DimensionSchema that = (DimensionSchema) o;
+
+    return name.equals(that.name);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return name.hashCode();
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -18,50 +18,86 @@
 package io.druid.data.input.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.metamx.common.parsers.ParserUtils;
 
-import java.util.Collections;
+import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 
 public class DimensionsSpec
 {
-  private final List<String> dimensions;
+  private final List<DimensionSchema> dimensions;
   private final Set<String> dimensionExclusions;
-  private final List<SpatialDimensionSchema> spatialDimensions;
+  private final Map<String, DimensionSchema> dimensionSchemaMap;
+
+  public static List<DimensionSchema> getDefaultSchemas(List<String> dimNames)
+  {
+    return Lists.transform(
+        dimNames,
+        new Function<String, DimensionSchema>()
+        {
+          @Override
+          public DimensionSchema apply(String input)
+          {
+            return new StringDimensionSchema(input);
+          }
+        }
+    );
+  }
+
+  public static DimensionSchema convertSpatialSchema(SpatialDimensionSchema spatialSchema)
+  {
+    return new NewSpatialDimensionSchema(spatialSchema.getDimName(), spatialSchema.getDims());
+  }
 
   @JsonCreator
   public DimensionsSpec(
-      @JsonProperty("dimensions") List<String> dimensions,
+      @JsonProperty("dimensions") List<DimensionSchema> dimensions,
       @JsonProperty("dimensionExclusions") List<String> dimensionExclusions,
-      @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
+      @Deprecated @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
   )
   {
     this.dimensions = dimensions == null
-                      ? Lists.<String>newArrayList()
+                      ? Lists.<DimensionSchema>newArrayList()
                       : Lists.newArrayList(dimensions);
 
     this.dimensionExclusions = (dimensionExclusions == null)
                                ? Sets.<String>newHashSet()
                                : Sets.newHashSet(dimensionExclusions);
 
-    this.spatialDimensions = (spatialDimensions == null)
-                             ? Lists.<SpatialDimensionSchema>newArrayList()
-                             : spatialDimensions;
+    List<SpatialDimensionSchema> spatialDims = (spatialDimensions == null)
+                                               ? Lists.<SpatialDimensionSchema>newArrayList()
+                                               : spatialDimensions;
 
-    verify();
+    verify(spatialDims);
+
+    // Map for easy dimension name-based schema lookup
+    this.dimensionSchemaMap = new HashMap<>();
+    for (DimensionSchema schema : this.dimensions) {
+      dimensionSchemaMap.put(schema.getName(), schema);
+    }
+
+    for(SpatialDimensionSchema spatialSchema : spatialDims) {
+      DimensionSchema newSchema = DimensionsSpec.convertSpatialSchema(spatialSchema);
+      this.dimensions.add(newSchema);
+      dimensionSchemaMap.put(newSchema.getName(), newSchema);
+    }
   }
 
+
   @JsonProperty
-  public List<String> getDimensions()
+  public List<DimensionSchema> getDimensions()
   {
     return dimensions;
   }
@@ -72,10 +108,49 @@ public class DimensionsSpec
     return dimensionExclusions;
   }
 
-  @JsonProperty
+  @Deprecated @JsonIgnore
   public List<SpatialDimensionSchema> getSpatialDimensions()
   {
-    return spatialDimensions;
+    Iterable<NewSpatialDimensionSchema> filteredList = Iterables.filter(
+        dimensions, NewSpatialDimensionSchema.class
+    );
+
+    Iterable<SpatialDimensionSchema> transformedList = Iterables.transform(
+        filteredList,
+        new Function<NewSpatialDimensionSchema, SpatialDimensionSchema>()
+        {
+          @Nullable
+          @Override
+          public SpatialDimensionSchema apply(NewSpatialDimensionSchema input)
+          {
+            return new SpatialDimensionSchema(input.getName(), input.getDims());
+          }
+        }
+    );
+
+    return Lists.newArrayList(transformedList);
+  }
+
+
+  @JsonIgnore
+  public List<String> getDimensionNames()
+  {
+    return Lists.transform(
+        dimensions,
+        new Function<DimensionSchema, String>()
+        {
+          @Override
+          public String apply(DimensionSchema input)
+          {
+            return input.getName();
+          }
+        }
+    );
+  }
+
+  public DimensionSchema getSchema(String dimension)
+  {
+    return dimensionSchemaMap.get(dimension);
   }
 
   public boolean hasCustomDimensions()
@@ -83,9 +158,9 @@ public class DimensionsSpec
     return !(dimensions == null || dimensions.isEmpty());
   }
 
-  public DimensionsSpec withDimensions(List<String> dims)
+  public DimensionsSpec withDimensions(List<DimensionSchema> dims)
   {
-    return new DimensionsSpec(dims, ImmutableList.copyOf(dimensionExclusions), spatialDimensions);
+    return new DimensionsSpec(dims, ImmutableList.copyOf(dimensionExclusions), null);
   }
 
   public DimensionsSpec withDimensionExclusions(Set<String> dimExs)
@@ -93,37 +168,41 @@ public class DimensionsSpec
     return new DimensionsSpec(
         dimensions,
         ImmutableList.copyOf(Sets.union(dimensionExclusions, dimExs)),
-        spatialDimensions
+        null
     );
   }
 
+  @Deprecated
   public DimensionsSpec withSpatialDimensions(List<SpatialDimensionSchema> spatials)
   {
     return new DimensionsSpec(dimensions, ImmutableList.copyOf(dimensionExclusions), spatials);
   }
 
-  private void verify()
+  private void verify(List<SpatialDimensionSchema> spatialDimensions)
   {
+    List<String> dimNames = getDimensionNames();
     Preconditions.checkArgument(
-        Sets.intersection(this.dimensionExclusions, Sets.newHashSet(this.dimensions)).isEmpty(),
+        Sets.intersection(this.dimensionExclusions, Sets.newHashSet(dimNames)).isEmpty(),
         "dimensions and dimensions exclusions cannot overlap"
     );
 
-    ParserUtils.validateFields(dimensions);
+    ParserUtils.validateFields(dimNames);
     ParserUtils.validateFields(dimensionExclusions);
-    ParserUtils.validateFields(
-        Iterables.transform(
-            spatialDimensions,
-            new Function<SpatialDimensionSchema, String>()
-            {
-              @Override
-              public String apply(SpatialDimensionSchema input)
-              {
-                return input.getDimName();
-              }
-            }
-        )
+
+    List<String> spatialDimNames = Lists.transform(
+        spatialDimensions,
+        new Function<SpatialDimensionSchema, String>()
+        {
+          @Override
+          public String apply(SpatialDimensionSchema input)
+          {
+            return input.getDimName();
+          }
+        }
     );
+
+    // Don't allow duplicates between main list and deprecated spatial list
+    ParserUtils.validateFields(Iterables.concat(dimNames, spatialDimNames));
   }
 
   @Override
@@ -141,11 +220,8 @@ public class DimensionsSpec
     if (!dimensions.equals(that.dimensions)) {
       return false;
     }
-    if (!dimensionExclusions.equals(that.dimensionExclusions)) {
-      return false;
-    }
-    return spatialDimensions.equals(that.spatialDimensions);
 
+    return dimensionExclusions.equals(that.dimensionExclusions);
   }
 
   @Override
@@ -153,7 +229,6 @@ public class DimensionsSpec
   {
     int result = dimensions.hashCode();
     result = 31 * result + dimensionExclusions.hashCode();
-    result = 31 * result + spatialDimensions.hashCode();
     return result;
   }
 }

--- a/src/main/java/io/druid/data/input/impl/FloatDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/FloatDimensionSchema.java
@@ -1,0 +1,48 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FloatDimensionSchema extends DimensionSchema
+{
+  @JsonCreator
+  public FloatDimensionSchema(
+      @JsonProperty("name") String name
+  )
+  {
+    super(name);
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return DimensionSchema.FLOAT_TYPE_NAME;
+  }
+
+  @Override
+  @JsonIgnore
+  public ValueType getValueType()
+  {
+    return ValueType.FLOAT;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/LongDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/LongDimensionSchema.java
@@ -1,0 +1,48 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LongDimensionSchema extends DimensionSchema
+{
+  @JsonCreator
+  public LongDimensionSchema(
+      @JsonProperty("name") String name
+  )
+  {
+    super(name);
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return DimensionSchema.LONG_TYPE_NAME;
+  }
+
+  @Override
+  @JsonIgnore
+  public ValueType getValueType()
+  {
+    return ValueType.LONG;
+  }
+}

--- a/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
+++ b/src/main/java/io/druid/data/input/impl/MapInputRowParser.java
@@ -46,7 +46,7 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
   public InputRow parse(Map<String, Object> theMap)
   {
     final List<String> dimensions = parseSpec.getDimensionsSpec().hasCustomDimensions()
-                                    ? parseSpec.getDimensionsSpec().getDimensions()
+                                    ? parseSpec.getDimensionsSpec().getDimensionNames()
                                     : Lists.newArrayList(
                                         Sets.difference(
                                             theMap.keySet(),

--- a/src/main/java/io/druid/data/input/impl/NewSpatialDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/NewSpatialDimensionSchema.java
@@ -24,33 +24,44 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
+ * NOTE: 
+ * This class should be deprecated after Druid supports configurable index types on dimensions.
+ * When that exists, this should be the implementation: https://github.com/druid-io/druid/issues/2622
+ * 
+ * This is a stop-gap solution to consolidate the dimension specs and remove the separate spatial 
+ * section in DimensionsSpec.
  */
-@Deprecated
-public class SpatialDimensionSchema
+public class NewSpatialDimensionSchema extends DimensionSchema
 {
-  private final String dimName;
   private final List<String> dims;
 
   @JsonCreator
-  public SpatialDimensionSchema(
-      @JsonProperty("dimName") String dimName,
+  public NewSpatialDimensionSchema(
+      @JsonProperty("name") String name,
       @JsonProperty("dims") List<String> dims
   )
   {
-    this.dimName = dimName;
+    super(name);
     this.dims = dims;
-  }
-
-  @JsonProperty
-  public String getDimName()
-  {
-    return dimName;
   }
 
   @JsonProperty
   public List<String> getDims()
   {
     return dims;
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return DimensionSchema.SPATIAL_TYPE_NAME;
+  }
+
+  @Override
+  @JsonIgnore
+  public ValueType getValueType()
+  {
+    return ValueType.STRING;
   }
 
   @Override
@@ -63,11 +74,8 @@ public class SpatialDimensionSchema
       return false;
     }
 
-    SpatialDimensionSchema that = (SpatialDimensionSchema) o;
+    NewSpatialDimensionSchema that = (NewSpatialDimensionSchema) o;
 
-    if (dimName != null ? !dimName.equals(that.dimName) : that.dimName != null) {
-      return false;
-    }
     return dims != null ? dims.equals(that.dims) : that.dims == null;
 
   }
@@ -75,8 +83,6 @@ public class SpatialDimensionSchema
   @Override
   public int hashCode()
   {
-    int result = dimName != null ? dimName.hashCode() : 0;
-    result = 31 * result + (dims != null ? dims.hashCode() : 0);
-    return result;
+    return dims != null ? dims.hashCode() : 0;
   }
 }

--- a/src/main/java/io/druid/data/input/impl/RegexParseSpec.java
+++ b/src/main/java/io/druid/data/input/impl/RegexParseSpec.java
@@ -51,7 +51,7 @@ public class RegexParseSpec extends ParseSpec
     this.columns = columns;
     this.pattern = pattern;
 
-    verify(dimensionsSpec.getDimensions());
+    verify(dimensionsSpec.getDimensionNames());
   }
 
   @JsonProperty

--- a/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
+++ b/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
@@ -1,0 +1,53 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StringDimensionSchema extends DimensionSchema
+{
+  @JsonCreator
+  public static StringDimensionSchema create(String name) {
+    return new StringDimensionSchema(name);
+  }
+
+  @JsonCreator
+  public StringDimensionSchema(
+      @JsonProperty("name") String name
+  )
+  {
+    super(name);
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return DimensionSchema.STRING_TYPE_NAME;
+  }
+
+  @Override
+  @JsonIgnore
+  public ValueType getValueType()
+  {
+    return ValueType.STRING;
+  }
+}

--- a/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/CSVParseSpecTest.java
@@ -37,7 +37,7 @@ public class CSVParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -56,7 +56,7 @@ public class CSVParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a,", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a,", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/DelimitedParseSpecTest.java
@@ -38,7 +38,7 @@ public class DelimitedParseSpecTest
   {
     DelimitedParseSpec spec = new DelimitedParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "\u0001",
         "\u0002",
         Arrays.asList("abc")
@@ -53,7 +53,7 @@ public class DelimitedParseSpecTest
     Assert.assertEquals(Arrays.asList("abc"), serde.getColumns());
     Assert.assertEquals("\u0001", serde.getDelimiter());
     Assert.assertEquals("\u0002", serde.getListDelimiter());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -66,7 +66,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -86,7 +86,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a,", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a,", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -105,7 +105,7 @@ public class DelimitedParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
@@ -1,0 +1,78 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.input.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ */
+public class DimensionsSpecSerdeTest
+{
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testDimensionsSpecSerde() throws Exception
+  {
+    DimensionsSpec expected = new DimensionsSpec(
+        Arrays.asList(
+            new StringDimensionSchema("AAA"),
+            new StringDimensionSchema("BBB"),
+            new FloatDimensionSchema("C++"),
+            new NewSpatialDimensionSchema("DDT", null),
+            new LongDimensionSchema("EEE"),
+            new NewSpatialDimensionSchema("DDT2", Arrays.asList("A", "B")),
+            new NewSpatialDimensionSchema("IMPR", Arrays.asList("S", "P", "Q", "R"))
+        ),
+        Arrays.asList("FOO", "HAR"),
+        null
+    );
+
+    String jsonStr = "{\"dimensions\":"
+                     + "[\"AAA\", \"BBB\","
+                     + "{\"name\":\"C++\", \"type\":\"float\"},"
+                     + "{\"name\":\"DDT\", \"type\":\"spatial\"},"
+                     + "{\"name\":\"EEE\", \"type\":\"long\"},"
+                     + "{\"name\":\"DDT2\", \"type\": \"spatial\", \"dims\":[\"A\", \"B\"]}],"
+                     + "\"dimensionExclusions\": [\"FOO\", \"HAR\"],"
+                     + "\"spatialDimensions\": [{\"dimName\":\"IMPR\", \"dims\":[\"S\",\"P\",\"Q\",\"R\"]}]"
+                     + "}";
+
+    DimensionsSpec actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(jsonStr, DimensionsSpec.class)
+        ),
+        DimensionsSpec.class
+    );
+
+    List<SpatialDimensionSchema> expectedSpatials = Arrays.asList(
+        new SpatialDimensionSchema("DDT", null),
+        new SpatialDimensionSchema("DDT2", Arrays.asList("A","B")),
+        new SpatialDimensionSchema("IMPR", Arrays.asList("S","P","Q","R"))
+    );
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(expectedSpatials, actual.getSpatialDimensions());
+  }
+}

--- a/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
+++ b/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
@@ -63,7 +63,7 @@ public class FileIteratingFirehoseTest
       final StringInputRowParser parser = new StringInputRowParser(
           new CSVParseSpec(
               new TimestampSpec("ts", "auto", null),
-              new DimensionsSpec(ImmutableList.of("x"), null, null),
+              new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("x")), null, null),
               ",",
               ImmutableList.of("ts", "x")
           )

--- a/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -46,7 +46,7 @@ public class InputRowParserSerdeTest
     final StringInputRowParser parser = new StringInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
             null
         )
@@ -89,7 +89,7 @@ public class InputRowParserSerdeTest
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timeposix", "posix", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), ImmutableList.of("baz"), null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), ImmutableList.of("baz"), null),
             null,
             null
         )
@@ -118,7 +118,7 @@ public class InputRowParserSerdeTest
     final MapInputRowParser parser = new MapInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timemillis", "millis", null),
-            new DimensionsSpec(ImmutableList.of("foo", "values"), ImmutableList.of("toobig", "value"), null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "values")), ImmutableList.of("toobig", "value"), null),
             null,
             null
         )
@@ -155,7 +155,7 @@ public class InputRowParserSerdeTest
     final StringInputRowParser parser = new StringInputRowParser(
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(ImmutableList.of("foo", "bar"), null, null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
             null
         ),

--- a/src/test/java/io/druid/data/input/impl/JSONLowercaseParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONLowercaseParseSpecTest.java
@@ -40,7 +40,7 @@ public class JSONLowercaseParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("A", "B"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("A", "B")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         )

--- a/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -41,7 +41,7 @@ public class JSONParseSpecTest {
     feature.put("ALLOW_UNQUOTED_CONTROL_CHARS", true);
     JSONParseSpec spec = new JSONParseSpec(
         new TimestampSpec("timestamp", "iso", null),
-        new DimensionsSpec(ImmutableList.of("bar", "foo"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
         null,
         feature
     );
@@ -53,7 +53,7 @@ public class JSONParseSpecTest {
     Assert.assertEquals("timestamp", serde.getTimestampSpec().getTimestampColumn());
     Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
 
-    Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensionNames());
     Assert.assertEquals(feature, serde.getFeatureSpec());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
@@ -38,7 +38,7 @@ public class JavaScriptParseSpecTest
   {
     JavaScriptParseSpec spec = new JavaScriptParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "abc"
     );
     final JavaScriptParseSpec serde = jsonMapper.readValue(
@@ -49,6 +49,6 @@ public class JavaScriptParseSpecTest
     Assert.assertEquals("iso", serde.getTimestampSpec().getTimestampFormat());
 
     Assert.assertEquals("abc", serde.getFunction());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
+++ b/src/test/java/io/druid/data/input/impl/NoopInputRowParserTest.java
@@ -64,7 +64,7 @@ public class NoopInputRowParserTest
         new NoopInputRowParser(
             new TimeAndDimsParseSpec(
                 null,
-                new DimensionsSpec(ImmutableList.of("host"), null, null)
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null)
             )
         ),
         actual

--- a/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
@@ -37,7 +37,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "b", "a"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "b", "a")),
             Lists.<String>newArrayList(),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -57,7 +57,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a", "B"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a", "B")),
             Lists.newArrayList("B"),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
@@ -77,7 +77,7 @@ public class ParseSpecTest
             null
         ),
         new DimensionsSpec(
-            Arrays.asList("a"),
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("a")),
             Lists.newArrayList("B", "B"),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),

--- a/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/RegexParseSpecTest.java
@@ -38,7 +38,7 @@ public class RegexParseSpecTest
   {
     RegexParseSpec spec = new RegexParseSpec(
         new TimestampSpec("abc", "iso", null),
-        new DimensionsSpec(Arrays.asList("abc"), null, null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "\u0001",
         Arrays.asList("abc"),
         "abc"
@@ -52,6 +52,6 @@ public class RegexParseSpecTest
 
     Assert.assertEquals("abc", serde.getPattern());
     Assert.assertEquals("\u0001", serde.getListDelimiter());
-    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensions());
+    Assert.assertEquals(Arrays.asList("abc"), serde.getDimensionsSpec().getDimensionNames());
   }
 }

--- a/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
+++ b/src/test/java/io/druid/data/input/impl/TimeAndDimsParseSpecTest.java
@@ -64,7 +64,7 @@ public class TimeAndDimsParseSpecTest
     Assert.assertEquals(
         new TimeAndDimsParseSpec(
             new TimestampSpec("tcol", null, null),
-            new DimensionsSpec(ImmutableList.of("host"), null, null)
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null)
         ),
         actual
     );


### PR DESCRIPTION
This PR changes the way dimensions are specified in the DimensionsSpec.

Instead of a String name, a new DimensionSchema class has been introduced, which specifies dimension type and additional properties. 

This change is made to support long and float-typed dimensions within Druid.

The user can still pass in String names into the DimensionsSpec; this will create the default String-type dimension.

This PR also deprecates the "spatialDimensions" field; spatial dimensions are now represented with a subclass of DimensionSchema, and stored in the main "dimensions" list. 

The user can still use the old "spatialDimensions" field; spatial dims within that list will be converted to the new form.
